### PR TITLE
fix: resolve WORKSPACE to user project dir, not plugin dir (#5)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -58,9 +58,16 @@ import type { SearchResult } from "./lib/types.ts";
 // ---------------------------------------------------------------------------
 
 const PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT || process.cwd();
-// WORKSPACE = user's project dir. MCP server inherits cwd from Claude Code.
-// npm --prefix installs deps in PLUGIN_ROOT, but tsx runs with inherited cwd.
-const WORKSPACE = process.cwd();
+// WORKSPACE = user's project dir. .mcp.json's launch wrapper `cd`s into
+// PLUGIN_ROOT to find node_modules before exec'ing tsx, which makes
+// process.cwd() resolve to the plugin dir instead of the user's project.
+// OLDPWD is set by that `cd` and reliably points to Claude Code's original
+// cwd (the user's project). Prefer CLAUDE_PROJECT_DIR if Claude Code exports
+// it, then OLDPWD, then process.cwd() as a last resort.
+const WORKSPACE =
+  process.env.CLAUDE_PROJECT_DIR ||
+  process.env.OLDPWD ||
+  process.cwd();
 const MEMORY_DIR = path.join(WORKSPACE, "memory");
 const DREAMS_DIR = path.join(MEMORY_DIR, ".dreams");
 


### PR DESCRIPTION
## What

Fixes #5.

`server.ts` sets `WORKSPACE = process.cwd()`, but `.mcp.json` runs the server with `cd "${CLAUDE_PLUGIN_ROOT}"` first (so `npm --prefix` can find `node_modules/`). That `cd` clobbers the user's project dir, so every MCP tool that reads `WORKSPACE` or `MEMORY_DIR` — `memory_search`, `memory_get`, `memory_context`, `agent_status`, `agent_config`, `dreaming`, etc. — silently reads the plugin repo's bundled `memory/` instead of the user's real one.

Identity injection (SOUL / IDENTITY / USER) is unaffected because `hooks/hooks.json` already uses `${CLAUDE_PROJECT_DIR:-$PWD}`. That inconsistency between the hook path logic and the MCP server's `process.cwd()` is exactly what makes the bug easy to miss — the agent *feels* wired up correctly because identity loads fine, while memory is silently reading the wrong folder.

## Fix

Three-step fallback in `server.ts`, mirroring what the hooks already do:

```ts
const WORKSPACE =
  process.env.CLAUDE_PROJECT_DIR ||  // forward-compatible if Claude Code adds it
  process.env.OLDPWD ||              // set by .mcp.json's `cd` — works today
  process.cwd();                     // last resort
```

- `CLAUDE_PROJECT_DIR` is not currently exported to the MCP subprocess env, but adding it first keeps the fix forward-compatible with potential Claude Code changes.
- `OLDPWD` is set by the `cd` in the launcher and reliably points at Claude Code's original cwd — this is the one that actually resolves today.
- `process.cwd()` remains as a last resort for anyone running the server without the `cd` trick.

## Verification

Locally on a `/home/claude` workspace with ClawCode cloned into `/home/claude/ClawCode/`:

```
WORKSPACE: /home/claude
MEMORY_DIR: /home/claude/memory
```

`memory_search` now hits the user's memory; `loadConfig(WORKSPACE)` finds the user's `agent-config.json`.

## Not changed

- Hooks and skills were already correct — not touched.
- No behavior change when users run the server outside the `.mcp.json` flow (`OLDPWD` empty → falls through to `process.cwd()` as before).