### PR TITLE
feat(service): harden defaults — env, crash-loop guard, persistent logs

### DIFF
--- a/docs/service.md
+++ b/docs/service.md
@@ -73,14 +73,21 @@ The `/agent:service install` skill asks for explicit confirmation before generat
     </array>
     <key>WorkingDirectory</key>
     <string>/Users/you/my-agent</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>/Users/you</string>
+        <key>TERM</key>
+        <string>xterm-256color</string>
+    </dict>
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
     <true/>
     <key>StandardOutPath</key>
-    <string>/tmp/clawcode-my-agent.log</string>
+    <string>/Users/you/.clawcode/logs/my-agent.log</string>
     <key>StandardErrorPath</key>
-    <string>/tmp/clawcode-my-agent.log</string>
+    <string>/Users/you/.clawcode/logs/my-agent.log</string>
     <key>ProcessType</key>
     <string>Interactive</string>
 </dict>
@@ -97,12 +104,16 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=/home/you/my-agent
+Environment=HOME=/home/you
+Environment=TERM=xterm-256color
 ExecStartPre=-/usr/bin/pkill -f "claude.*--dangerously-skip-permissions"
 ExecStart=/usr/local/bin/claude --dangerously-skip-permissions
 Restart=always
 RestartSec=10
-StandardOutput=append:/tmp/clawcode-my-agent.log
-StandardError=append:/tmp/clawcode-my-agent.log
+StartLimitIntervalSec=300
+StartLimitBurst=5
+StandardOutput=append:/home/you/.clawcode/logs/my-agent.log
+StandardError=append:/home/you/.clawcode/logs/my-agent.log
 
 [Install]
 WantedBy=default.target
@@ -132,9 +143,9 @@ Remember: the more tools you load, the more attack surface the always-on agent h
 
 ## Logs
 
-Default log path: `/tmp/clawcode-<slug>.log`. Both stdout and stderr go there.
+Default log path: `~/.clawcode/logs/<slug>.log`. Both stdout and stderr go there. The install plan creates `~/.clawcode/logs/` automatically — without that, systemd's `append:` and launchd's `StandardOutPath` silently refuse to start the service.
 
-`/tmp` is cleared on reboot. If you want persistent logs, pass a custom `logPath` when installing — e.g. `~/.clawcode/logs/my-agent.log`. Log rotation is not handled — add your own `logrotate` rule or pipe through a rotator if needed.
+Persistent across reboots. Override with a custom `logPath` when installing if you want the file elsewhere. Log rotation is not handled — add your own `logrotate` rule or pipe through a rotator if needed.
 
 ## Resume-on-restart wrapper
 
@@ -155,7 +166,7 @@ The wrapper is regenerated every time `install` is run, so safe to re-run after 
 |---|---|---|
 | Service installed but WebChat / HTTP bridge never come up; logs empty or stuck before "listening" | Bypass Permissions startup dialog waiting for a "Do you accept?" that the daemon (launchd / systemd) cannot answer — no TTY | Add `"skipDangerousModePermissionPrompt": true` to `~/.claude/settings.json`, then restart the service. Only affects service mode; interactive `claude` is unaffected |
 | "service installed" but WebChat still unreachable | Service file is correct but `claude` not in PATH for launchd | Verify with `/agent:service status`; use absolute path to `claude` (`which claude` then pass as `claudeBin`) |
-| Service keeps crashing / restart loop | Config error (bad `agent-config.json`) or missing permission the `--dangerously-skip-permissions` flag can't cover | Check `/tmp/clawcode-<slug>.log`; run `/agent:doctor` to see if config is valid |
+| Service keeps crashing / restart loop | Config error (bad `agent-config.json`) or missing permission the `--dangerously-skip-permissions` flag can't cover | Check `~/.clawcode/logs/<slug>.log`; run `/agent:doctor` to see if config is valid. `StartLimitBurst=5` means systemd will stop retrying after 5 failures in 5 minutes — look for the last error there. |
 | On Linux: service dies when you log out | Lingering not enabled | `sudo loginctl enable-linger $USER` |
 | Uninstall didn't fully stop | systemd cache | `systemctl --user daemon-reload` then re-run uninstall |
 | Multiple agents conflicting | Same slug | Ensure workspace folder names are distinct |

--- a/lib/service-generator.ts
+++ b/lib/service-generator.ts
@@ -118,7 +118,9 @@ export function serviceFilePath(platform: Platform, slug: string): string {
 }
 
 export function defaultLogPath(slug: string): string {
-  return path.join("/tmp", `clawcode-${slug}.log`);
+  // Persistent per-user location. `/tmp` is wiped on reboot, making it
+  // near-useless for diagnosing failures that survived a restart cycle.
+  return path.join(os.homedir(), ".clawcode", "logs", `${slug}.log`);
 }
 
 /** Where the resume-on-restart wrapper script gets installed per service. */
@@ -251,6 +253,13 @@ ${argsXml}
     </array>
     <key>WorkingDirectory</key>
     <string>${xmlEscape(opts.workspace)}</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>${xmlEscape(os.homedir())}</string>
+        <key>TERM</key>
+        <string>xterm-256color</string>
+    </dict>
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
@@ -305,10 +314,16 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=${opts.workspace}
+Environment=HOME=${os.homedir()}
+Environment=TERM=xterm-256color
 ExecStartPre=-/usr/bin/pkill -f "claude.*--dangerously-skip-permissions"
 ExecStart=${execStart}
 Restart=always
 RestartSec=10
+# Crash-loop guard: stop restarting after 5 failures within 5 minutes
+# so a deterministic boot-time error doesn't churn forever.
+StartLimitIntervalSec=300
+StartLimitBurst=5
 StandardOutput=append:${opts.logPath}
 StandardError=append:${opts.logPath}
 
@@ -390,6 +405,13 @@ export function buildPlan(action: ServiceAction, opts: ServiceOptions): ServiceP
           });
 
     const commands: PlanCommand[] = [];
+    // Ensure the log directory exists first — systemd's `append:` and
+    // launchd's StandardOutPath do NOT create missing parent directories,
+    // and the service silently refuses to start if they don't.
+    commands.push({
+      label: "Create log directory",
+      cmd: `mkdir -p "${path.dirname(logPath)}"`,
+    });
     if (platform === "darwin") {
       commands.push({
         label: "Create LaunchAgents directory",


### PR DESCRIPTION
## What

Three orthogonal install-hardening items that each stand on their own:

1. **Inject `HOME` and `TERM` explicitly** into both systemd unit and launchd plist.
2. **Crash-loop guard** on systemd via `StartLimitIntervalSec=300` + `StartLimitBurst=5`.
3. **Persistent default log path** — `/tmp/clawcode-<slug>.log` → `~/.clawcode/logs/<slug>.log`, with install plan creating the dir.

## Why

### 1. Explicit `HOME` + `TERM`

systemd user services and launchd both start with a largely empty environment. Anything in Claude Code or a plugin that reads `\$HOME` (resolving `~`), or probes `\$TERM` (color output, TUI detection, several Node libraries), behaves unpredictably when those are unset. Some combinations fail loudly; more often they fail subtly — e.g. a skill that works interactively and then no-ops under the service with no clear error. Setting them at the unit/plist level is cheap and universally safe.

### 2. Crash-loop guard

With `Restart=always` and `RestartSec=10`, a deterministic boot-time error (bad config, missing binary, malformed `extraArgs`) churns forever at 10 s intervals, flooding logs and journald. `StartLimitIntervalSec=300` + `StartLimitBurst=5` tells systemd to give up after 5 restarts in 5 minutes so the failure surfaces in `systemctl status` instead of hiding in noise. No change on healthy services.

macOS launchd already has its own throttling (`ThrottleInterval`, `ExitTimeOut`), so no plist change is needed for this item.

### 3. Persistent log path

`/tmp` is wiped on reboot, so a service that auto-restarts *through* a reboot loses the log that explains why it was failing in the first place. Moving to `~/.clawcode/logs/` keeps logs available for post-mortem and matches where the rest of the agent's per-user state sits.

`systemd`'s `append:` and launchd's `StandardOutPath` do NOT create missing parent dirs and the service will silently refuse to start without them, so the install plan now includes a \"Create log directory\" command up front.

## Changes

**`lib/service-generator.ts`**
- `defaultLogPath` now returns `~/.clawcode/logs/<slug>.log` (was `/tmp/clawcode-<slug>.log`).
- `generateSystemdUnit` emits `Environment=HOME=...`, `Environment=TERM=xterm-256color`, `StartLimitIntervalSec=300`, `StartLimitBurst=5`.
- `generatePlist` emits `EnvironmentVariables` with `HOME` and `TERM`.
- `buildPlan` install action prepends a \"Create log directory\" command.

**`docs/service.md`**
- Example systemd unit and plist updated.
- Logs section reflects new default + explains why the log dir is created at install.
- Restart-loop troubleshooting row points at the new log location and mentions `StartLimitBurst` so users know to check `systemctl status` when systemd has given up.

## Verification

`bun -e` on the generator directly:

```
--- unit ---
[Unit]
Description=ClawCode Agent (claude)
After=network.target

[Service]
Type=simple
WorkingDirectory=/home/claude
Environment=HOME=/home/claude
Environment=TERM=xterm-256color
ExecStartPre=-/usr/bin/pkill -f \"claude.*--dangerously-skip-permissions\"
ExecStart=/usr/local/bin/claude --dangerously-skip-permissions
Restart=always
RestartSec=10
# Crash-loop guard: stop restarting after 5 failures within 5 minutes
# so a deterministic boot-time error doesn't churn forever.
StartLimitIntervalSec=300
StartLimitBurst=5
StandardOutput=append:/home/claude/.clawcode/logs/claude.log
StandardError=append:/home/claude/.clawcode/logs/claude.log

--- commands ---
  Create log directory: mkdir -p \"/home/claude/.clawcode/logs\"
  Create systemd user directory: mkdir -p \"/home/claude/.config/systemd/user\"
  Reload systemd: systemctl --user daemon-reload
  Enable + start the service: systemctl --user enable --now clawcode-claude.service
```

Plist output similarly verified — `EnvironmentVariables` dict with `HOME` and `TERM`, persistent `StandardOutPath`.

## Not changed (explicitly)

- `ExecStartPre=-/usr/bin/pkill ...` from v1.3.0 left alone — it's the right answer for the multi-instance race.
- `Restart=always` and `RestartSec=10` kept. These are opinionated and the current defaults are reasonable; crash-loop guard is the right fix for their only real downside.
- No `script(1)`-wrap of `ExecStart`. I run this locally and it's arguably helpful for some skills that expect a PTY, but the value is niche enough that it doesn't belong in a default.

## Relationship to other PRs

- Independent of #6 (`fix: resolve WORKSPACE ...`) — no overlap.
- Independent of #7 (`feat(service): resume-on-restart wrapper`) — no file overlap; both PRs can land in either order. If they both land, the wrapper PR's `extraFiles` writing happens in the same install flow as this PR's `Create log directory` command.