### PR TITLE
fix(service): wrap systemd ExecStart in PTY, disable auto-updater

### DIFF
--- a/lib/service-generator.ts
+++ b/lib/service-generator.ts
@@ -171,7 +171,17 @@ export function generateSystemdUnit(opts: {
   const execStartParts = [opts.claudeBin, ...args].map((a) =>
     /\s/.test(a) ? `"${shellEscape(a)}"` : a
   );
-  const execStart = execStartParts.join(" ");
+  // Wrap the invocation in `script -q -c '...' /dev/null` so claude runs
+  // under a PTY. Without a PTY, Claude Code's SessionEnd (and other
+  // lifecycle) hooks cannot spawn `/bin/sh`, graceful exits return code 1
+  // instead of 0, and `Restart=on-failure`/`always` produces a crash loop
+  // on every normal shutdown. The inner single-quoted command is re-parsed
+  // by `script`'s child /bin/sh, which strips the outer quotes — so any
+  // literal single-quote in a path/arg must be escaped with '\''.
+  const innerCmd = execStartParts
+    .map((a) => a.replace(/'/g, `'\\''`))
+    .join(" ");
+  const execStart = `/usr/bin/script -q -c '${innerCmd}' /dev/null`;
 
   return `[Unit]
 Description=ClawCode Agent (${opts.name})
@@ -180,6 +190,11 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=${opts.workspace}
+# Disable Claude Code's in-process auto-updater while running as a daemon.
+# Background updates have regenerated service files and left the system in
+# inconsistent states; pin the installed version and update explicitly via
+# package manager instead.
+Environment=DISABLE_AUTOUPDATER=1
 ExecStartPre=-/usr/bin/pkill -f "claude.*--dangerously-skip-permissions"
 ExecStart=${execStart}
 Restart=always


### PR DESCRIPTION
## Summary

Two defensive fixes for a systemd-daemonized ClawCode service entering a permanent restart loop after Claude Code's in-process auto-updater regenerates its own installation mid-run.

- Wrap `ExecStart` in `/usr/bin/script -q -c '...' /dev/null` so `claude` runs under a PTY. Without one, Claude Code's `SessionEnd` (and other lifecycle) hooks cannot spawn `/bin/sh`; graceful shutdown returns exit code 1 instead of 0, and `Restart=always` / `Restart=on-failure` produces a deterministic loop on every otherwise-clean restart.
- Inject `Environment=DISABLE_AUTOUPDATER=1` so the in-process auto-updater cannot silently regenerate service files mid-run. Pin the installed version; update explicitly via the package manager instead. (Verified that `DISABLE_AUTOUPDATER` is the env var `cli.js` actually reads.)

## Failure mode this fixes

Reproduced in the wild on Linux + systemd:

1. Service starts normally; `claude` is 2.1.104.
2. `claude` auto-updates itself to 2.1.107 while running, which regenerates wrapper scripts it installed.
3. The regenerated invocation no longer runs under a PTY.
4. On the next normal shutdown, `SessionEnd` fails to spawn `/bin/sh`, exit code is 1.
5. `Restart=on-failure` fires. Back to step 3. Forever.

The PTY wrap makes step 3 unreachable from a clean install. `DISABLE_AUTOUPDATER=1` defuses step 2 as defense-in-depth — so the fix holds even if Claude Code's updater logic changes in the future.

## Why `DISABLE_AUTOUPDATER` is the right default for daemon mode

Auto-update isn't inherently unsafe — in an interactive `claude` session, it works well because sessions are short and the old process exits cleanly before the operator starts the next one. For a long-running daemon it's a different story:

| | Auto-update | Manual update (`npm install -g ... && systemctl restart`) |
|---|---|---|
| Binary swap | Whenever the updater fires | When the operator runs it |
| Restart after swap | Only when process naturally exits — may be hours/days | Immediately |
| Duration of "old process, new binary on disk" mismatch | Unbounded | Seconds |
| Shutdown mechanism | Unexpected (crash, external trigger) | Orchestrated SIGTERM |
| Rollback on breakage | Guess which version broke it | `npm install ...@<prev>` then restart |

The core insight: auto-update is *asynchronous with restart*, and that window of "old process in memory, new binary on disk" is what makes the transition unsafe. Manual update collapses the window to seconds and makes the restart explicit, so `SessionEnd` runs on code that matches what the on-disk binary expected to find on exit.

This PR only changes the default for service-mode installations (the generated systemd unit). Interactive `claude` elsewhere on the system is unaffected.

## Scope

- **systemd only.** macOS launchd sets `ProcessType=Interactive`, which may already provide TTY-ish stdio. `generatePlist` is intentionally unchanged in this PR. If the same hook-spawn failure turns out to be reproducible on launchd, a parallel fix can follow.
- **Pure default change.** No new public options. No behavioral difference for healthy services — this only makes the failure path converge on success instead of looping.

## Companion PR (to follow)

Disabling auto-updates without a "new version available" signal means users silently fall behind. A follow-up PR will add a version-check heartbeat step + `/agent:update` skill that detects new versions, surfaces them to the user, and prints the safe update command. That's additive — this PR stands on its own.

## Interaction with other open PRs

- #7 (resume-on-restart wrapper) exec's `claude` from a generated bash wrapper. With this PR merged, the outer `script -q -c '<wrapper.sh>'` supplies the PTY and the wrapper's `exec` inherits it, so the two are complementary. **Without this PR, #7 alone reproduces the crash loop on any user who encounters an auto-update mid-run.**
- #8 (service hardening) is orthogonal. The `StartLimitBurst` crash-loop guard from #8 is what surfaces this failure in `systemctl status` instead of hiding it in log spam — a nice diagnostic pairing.

## Test plan

- [ ] `/agent:service install` produces a unit file with `ExecStart=/usr/bin/script -q -c '...' /dev/null` and `Environment=DISABLE_AUTOUPDATER=1`
- [ ] Service starts, runs, and restarts cleanly; no exit-1 loop on graceful shutdown
- [ ] `systemctl --user show <slug>` reports `DISABLE_AUTOUPDATER=1` under `Environment`
- [ ] macOS install still produces a valid plist (no regressions in `generatePlist`)
- [ ] Single-quoted paths in `claudeBin` or `extraArgs` survive the escape (e.g. `/home/foo's bar/claude`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
