### PR TITLE
fix(import): support cross-user OpenClaw sources + post-import path check

### DIFF
--- a/skills/import/SKILL.md
+++ b/skills/import/SKILL.md
@@ -11,21 +11,41 @@ Import an existing agent from an OpenClaw installation into this directory, then
 
 ## Part 1: Copy the agent
 
-1. **List available OpenClaw agents**:
+1. **Discover OpenClaw workspaces** across plausible source locations. Users
+   commonly run OpenClaw as `root` and then run ClawCode as a non-root user
+   (e.g. inside an LXC where the service user is `claude`), so checking only
+   `~/.openclaw` misses those setups. Look in every readable root below and
+   union the results:
+
    ```bash
-   ls -d ~/.openclaw/workspace* 2>/dev/null
+   for root in \
+     "${CLAWCODE_OPENCLAW_ROOT:-}" \
+     "$HOME/.openclaw" \
+     "/root/.openclaw"; do
+     [[ -z "$root" ]] && continue
+     [[ -r "$root" ]] || continue
+     ls -d "$root"/workspace* 2>/dev/null
+   done | sort -u
    ```
-   
-   For each workspace, read IDENTITY.md to show the agent's name:
-   - `~/.openclaw/workspace/` — default agent (main)
-   - `~/.openclaw/workspace-eva/` — agent "eva"
-   - `~/.openclaw/workspace-jack/` — agent "jack"
+
+   Override the search roots with the `CLAWCODE_OPENCLAW_ROOT` env var when
+   OpenClaw data lives in a non-standard location (e.g. a mounted volume).
+
+   If the loop returns nothing, ask the user for an absolute path to the
+   source workspace instead of silently falling back.
+
+   For each workspace found, read `IDENTITY.md` to show the agent's name.
+   Typical layouts:
+   - `<root>/workspace/` — default agent (main)
+   - `<root>/workspace-eva/` — agent "eva"
+   - `<root>/workspace-jack/` — agent "jack"
 
 2. **Let the user choose** which agent to import (or use argument if provided).
 
-3. **Determine the source path**:
-   - Default/main: `~/.openclaw/workspace/`
-   - Named agent: `~/.openclaw/workspace-{id}/`
+3. **Determine the source path**: use the absolute path from the chosen
+   workspace (e.g. `/root/.openclaw/workspace-eva/` or
+   `/home/claude/.openclaw/workspace/`). Do NOT re-expand `~` from an
+   agent-id alone — the discovered path already carries the correct root.
 
 4. **Copy bootstrap files** to the current project root:
    Files to copy from the source workspace:
@@ -454,7 +474,48 @@ AskUserQuestion(
 
 If the user already has a messaging plugin installed (from a previous agent), offer to add its log directory to `memory.extraPaths` so past conversations become searchable.
 
-### Step G — Reload
+### Step G — Path sanity check
+
+After everything is copied and written, scan Claude Code's config files for
+absolute paths that point at a different user's home directory. This is the
+other half of the cross-user import problem: Claude Code writes absolute paths
+into its own settings when plugins are installed, and switching the runtime
+user (e.g. from `root` to `claude`) leaves those paths pointing at a home dir
+the new user can't read. Skills silently fail with "unknown skill" errors.
+
+ClawCode does NOT own these files, so don't auto-patch them — just detect and
+warn:
+
+```bash
+# Any absolute path in Claude Code's config that doesn't live under $HOME is
+# suspect. /root paths are the usual culprit after a user switch.
+for f in \
+  "$HOME/.claude/settings.json" \
+  "$HOME/.claude/installed_plugins.json" \
+  "./agent-config.json"; do
+  [[ -f "$f" ]] || continue
+  # Match quoted absolute paths; reject anything under $HOME.
+  grep -oE '"/[^"]+"' "$f" \
+    | tr -d '"' \
+    | grep -v "^$HOME/" \
+    | grep -v "^/usr/\|^/bin/\|^/etc/\|^/tmp/\|^/opt/" \
+    | while read -r p; do echo "$f → $p"; done
+done
+```
+
+For every hit, print a specific, fix-ready warning — e.g.:
+
+```
+⚠️ ~/.claude/installed_plugins.json references /root/.claude/plugins/...
+   but this agent runs as $(whoami) ($HOME). Skills from those plugins will
+   fail with "unknown skill". Fix with:
+
+   sed -i "s|/root/.claude|$HOME/.claude|g" ~/.claude/installed_plugins.json
+```
+
+If nothing is flagged, print one line: "Paths OK — no stale home-dir references."
+
+### Step H — Reload
 
 Tell the user to reload the MCP server so all the new config takes effect:
 ```


### PR DESCRIPTION
## What

Addresses item 11 of #4: `/agent:import` only looks for source workspaces under `~/.openclaw`, which fails when the user ran OpenClaw as one account (typically `root`) and now runs ClawCode as a non-root service user (typically `claude` inside an LXC or similar). A related half of the same problem is that Claude Code's own config files (`settings.json`, `installed_plugins.json`) keep absolute paths written at install time — so switching the runtime user leaves those paths dangling with silent "unknown skill" failures downstream.

Two changes, both in `skills/import/SKILL.md`:

### 1. Workspace discovery across plausible source roots

The old step was:

```bash
ls -d ~/.openclaw/workspace* 2>/dev/null
```

Replaced with a loop over every readable root we know about:

```bash
for root in \
  "${CLAWCODE_OPENCLAW_ROOT:-}" \
  "$HOME/.openclaw" \
  "/root/.openclaw"; do
  [[ -z "$root" ]] && continue
  [[ -r "$root" ]] || continue
  ls -d "$root"/workspace* 2>/dev/null
done | sort -u
```

- `CLAWCODE_OPENCLAW_ROOT` lets the user point at a mounted volume / non-standard location explicitly.
- `$HOME/.openclaw` is the existing default.
- `/root/.openclaw` is picked up when the current user happens to be able to read it (common in Docker/LXC setups where the container runs as a non-root user but can still read `/root`).

If the loop returns nothing, the skill now asks for an absolute path rather than silently falling back. The subsequent "determine source path" step uses the absolute path from the chosen workspace directly — no re-expanding `~` from an agent-id, which was the root of the cross-user bug.

### 2. New Step G — "Path sanity check"

After the import copies + skills/crons/messaging work, scan these config files for absolute paths that don't live under `$HOME` (excluding system dirs):

- `~/.claude/settings.json`
- `~/.claude/installed_plugins.json`
- `./agent-config.json`

For every hit, print a fix-ready `sed` command the user can run. Example output:

```
⚠️ ~/.claude/installed_plugins.json references /root/.claude/plugins/...
   but this agent runs as claude ($HOME = /home/claude). Skills from those
   plugins will fail with "unknown skill". Fix with:

   sed -i "s|/root/.claude|$HOME/.claude|g" ~/.claude/installed_plugins.json
```

ClawCode does not own `settings.json` / `installed_plugins.json`, so the step explicitly **does not** auto-patch. Detect-and-warn only; the user decides whether to apply.

## Why a skill-doc change, not code

The import flow is driven by the agent reading the SKILL.md procedure, so this is the code. No TS changes, no new binary paths, no generator changes. The existing Step G (Reload) is renumbered to Step H.

## Not addressed

- Item 11 also called out that installed_plugins.json can be invalid after a user switch. This PR surfaces it with a fix command but doesn't auto-repair. Auto-repairing Claude Code's own config from a ClawCode skill felt out of scope — happy to follow up with a separate PR if you'd prefer we take that step too.

## Test plan

- [ ] Fresh import on a system with only `$HOME/.openclaw/workspace*` — discovers workspaces as before, no behavior change
- [ ] Import on a system where OpenClaw lives only in `/root/.openclaw/` but the runtime user has read access — discovers workspaces that used to be invisible
- [ ] `CLAWCODE_OPENCLAW_ROOT=/mnt/backup/openclaw` — loop picks up that root first
- [ ] `/root/.openclaw` exists but is not readable — loop quietly skips it (no permission denied spam)
- [ ] Step G flags a seeded `"/root/.claude/plugins/foo"` entry in `installed_plugins.json` with the correct `sed` suggestion
- [ ] Step G prints the all-clear line when no stale paths exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)