### PR TITLE
feat(update): /agent:update skill + heartbeat version-check

### DIFF
--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: update
+description: Check for new versions of Claude Code and ClawCode, and print safe update commands. Triggers on /agent:update, /update, "check for updates", "are there updates", "buscar actualizaciones".
+user-invocable: true
+---
+
+# /agent:update — Check for new versions
+
+Detect whether new versions of Claude Code (`@anthropic-ai/claude-code`) or ClawCode (this repo) are available, and surface the safe update procedure for each. Designed for users running ClawCode as a long-running daemon, where Claude Code's in-process auto-updater is disabled (see `lib/service-generator.ts` — `Environment=DISABLE_AUTOUPDATER=1`) and updates have to be applied explicitly.
+
+## When to use
+
+- User asks `/agent:update`, `/update`, "check for updates", "are there updates", etc.
+- Heartbeat skill calls in silent-check mode (see `templates/HEARTBEAT.md`).
+- Before applying any change to the running service — knowing the upstream version helps decide whether to bundle with an update.
+
+## Steps
+
+1. **Detect current versions.** Run all three in parallel (independent reads):
+
+   ```bash
+   # Claude Code installed binary
+   CC_INSTALLED=$(claude --version 2>/dev/null | awk '{print $1}')
+
+   # ClawCode local repo HEAD
+   PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(pwd)/ClawCode}"
+   CW_LOCAL=$(git -C "$PLUGIN_ROOT" rev-parse --short HEAD 2>/dev/null)
+   CW_LOCAL_TAG=$(git -C "$PLUGIN_ROOT" describe --tags --abbrev=0 2>/dev/null || echo "no-tag")
+   ```
+
+2. **Detect available versions.** Network calls — be tolerant of failures (no network, npm flake, GitHub down):
+
+   ```bash
+   # Claude Code latest on npm
+   CC_LATEST=$(npm view @anthropic-ai/claude-code version 2>/dev/null)
+
+   # ClawCode latest tag and HEAD on upstream
+   git -C "$PLUGIN_ROOT" fetch upstream --tags 2>/dev/null
+   CW_UPSTREAM_HEAD=$(git -C "$PLUGIN_ROOT" rev-parse --short upstream/main 2>/dev/null)
+   CW_UPSTREAM_TAG=$(git -C "$PLUGIN_ROOT" describe --tags --abbrev=0 upstream/main 2>/dev/null || echo "no-tag")
+   ```
+
+   If any value is empty, treat that side as "unknown" rather than failing the whole check.
+
+3. **Compare and decide.** Two boolean signals: `CC_UPDATE_AVAILABLE` and `CW_UPDATE_AVAILABLE`.
+
+   - Claude Code: `CC_UPDATE_AVAILABLE=1` if `CC_INSTALLED` and `CC_LATEST` are both set and not equal.
+   - ClawCode: `CW_UPDATE_AVAILABLE=1` if `CW_LOCAL` and `CW_UPSTREAM_HEAD` are both set and `git merge-base --is-ancestor upstream/main HEAD` is **false** — i.e. upstream has commits the local repo doesn't yet have.
+
+4. **Surface the result.** Always show a status block. If updates are available, append the safe procedure for each.
+
+   ```
+   📦 *Update check*
+
+   Claude Code:    <CC_INSTALLED> → <CC_LATEST>   <✅ current | ⬆️ update available | ⚠️ unknown>
+   ClawCode:       <CW_LOCAL_TAG>+<CW_LOCAL> → <CW_UPSTREAM_TAG>+<CW_UPSTREAM_HEAD>   <✅ current | ⬆️ update available | ⚠️ unknown>
+   ```
+
+   When at least one update is available, append:
+
+   ```
+   To apply (in a root shell on the host running the service):
+
+     npm install -g @anthropic-ai/claude-code            # if Claude Code update
+     git -C <plugin-root> pull upstream main             # if ClawCode update
+     systemctl --user restart clawcode-<slug>.service    # always — picks up both
+   ```
+
+   Substitute `<plugin-root>` and `<slug>` from the actual service install (read from `~/.config/systemd/user/clawcode-*.service` if present, otherwise leave the placeholders).
+
+5. **On a messaging channel:** trim the output for mobile. Use the channel-appropriate `reply` tool (e.g. `mcp__plugin_telegram_telegram__reply`). Don't include long bash blocks — instead one short line per actionable update, and offer "want the full commands?" as a follow-up.
+
+## Permission notes
+
+- The `claude` user typically **cannot** run `npm install -g` (`/usr/local/lib/node_modules/` is root-owned). The skill detects + reports — it does **not** execute the install. The user (or their root-capable operator) runs the printed commands themselves.
+- `git pull` works as long as the user owns the plugin repo directory. ClawCode updates can be applied without elevation.
+- `systemctl --user restart` requires no root for user-mode services, but **kills the running session**. Warn before suggesting it during an active conversation.
+
+## Silent-check mode (called by heartbeat)
+
+When invoked from the heartbeat skill, the goal is *not* to spam the user every 30 minutes. Use a memory-backed dedupe so each new version is announced exactly once:
+
+```bash
+NOTIFIED_FILE="$AGENT_ROOT/memory/.notified-versions.json"
+# Read the last-notified version for each component.
+LAST_CC=$(jq -r '.["claude-code"] // ""' "$NOTIFIED_FILE" 2>/dev/null)
+LAST_CW=$(jq -r '.clawcode // ""' "$NOTIFIED_FILE" 2>/dev/null)
+
+# Only notify when the available version differs from BOTH the installed AND the last-notified.
+if [[ -n "$CC_LATEST" && "$CC_LATEST" != "$CC_INSTALLED" && "$CC_LATEST" != "$LAST_CC" ]]; then
+  # ping user, then record the new last-notified
+  jq --arg v "$CC_LATEST" '.["claude-code"] = $v' "$NOTIFIED_FILE" > "$NOTIFIED_FILE.tmp" \
+    && mv "$NOTIFIED_FILE.tmp" "$NOTIFIED_FILE"
+fi
+# Same shape for ClawCode.
+```
+
+Initialize the file as `{}` if it doesn't exist. The dedupe survives restarts because it's in `memory/`, not `/tmp`.
+
+Also gate on a coarser per-day check via `memory/.last-update-check` — heartbeat fires every 30 min but the network round-trip to npm + GitHub doesn't need to happen that often. Skip the network calls entirely if the marker's mtime is < 24h old; just compare against the cached state.
+
+## Notes
+
+- This skill never *applies* updates. It only detects, reports, and tells the user the safe command. That's deliberate — a daemonized agent that auto-applies updates to its own runtime is exactly what we just disabled.
+- If the plugin repo isn't a git checkout (rare — installed via plugin manager only), skip the ClawCode side gracefully and just check Claude Code.
+- Channel-specific formatting: WhatsApp uses `*bold*`; Telegram supports `**bold**` or HTML; CLI is plain markdown.

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -45,7 +45,7 @@ Detect whether new versions of Claude Code (`@anthropic-ai/claude-code`) or Claw
 3. **Compare and decide.** Two boolean signals: `CC_UPDATE_AVAILABLE` and `CW_UPDATE_AVAILABLE`.
 
    - Claude Code: `CC_UPDATE_AVAILABLE=1` if `CC_INSTALLED` and `CC_LATEST` are both set and not equal.
-   - ClawCode: `CW_UPDATE_AVAILABLE=1` if `CW_LOCAL` and `CW_UPSTREAM_HEAD` are both set and `git merge-base --is-ancestor upstream/main HEAD` is **false** — i.e. upstream has commits the local repo doesn't yet have.
+   - ClawCode: `CW_UPDATE_AVAILABLE=1` if `CW_LOCAL_TAG` and `CW_UPSTREAM_TAG` are both set, neither is `no-tag`, and they differ (i.e. upstream has cut a newer release tag). Plain commits on `upstream/main` (docs, chore, ci) do NOT trigger an update notification; otherwise routine upstream activity would teach users to ignore the pings.
 
 4. **Surface the result.** Always show a status block. If updates are available, append the safe procedure for each.
 
@@ -92,7 +92,8 @@ if [[ -n "$CC_LATEST" && "$CC_LATEST" != "$CC_INSTALLED" && "$CC_LATEST" != "$LA
   jq --arg v "$CC_LATEST" '.["claude-code"] = $v' "$NOTIFIED_FILE" > "$NOTIFIED_FILE.tmp" \
     && mv "$NOTIFIED_FILE.tmp" "$NOTIFIED_FILE"
 fi
-# Same shape for ClawCode.
+# Same shape for ClawCode, keyed by tag (CW_UPSTREAM_TAG), so each release is
+# announced once, and pure-chore upstream commits never trigger a notification.
 ```
 
 Initialize the file as `{}` if it doesn't exist. The dedupe survives restarts because it's in `memory/`, not `/tmp`.

--- a/templates/HEARTBEAT.md
+++ b/templates/HEARTBEAT.md
@@ -2,4 +2,5 @@
 
 - Quick scan: anything urgent in memory or pending messages?
 - Memory: consolidate recent daily logs into MEMORY.md if unreviewed
+- **Update check** — once per UTC day (skip if `memory/.last-update-check` is from today), invoke the `update` skill in silent-check mode. If it reports a new Claude Code or ClawCode version that hasn't been notified yet (dedupe via `memory/.notified-versions.json`), surface a one-line ping with the safe update command. Touch the marker after.
 - If daytime and nothing pending, stay quiet


### PR DESCRIPTION
## Summary

Companion to #9 — which disables Claude Code's in-process auto-updater for service-mode installs. Without an explicit update path, daemonized agents silently fall behind. This PR closes that loop with a detect-and-notify flow that doesn't introduce the very class of mid-run mutation #9 set out to prevent.

Two pieces:

### 1. New `/agent:update` skill (`skills/update/SKILL.md`)

User-invocable. Triggers on `/agent:update`, `/update`, "check for updates", "are there updates", "buscar actualizaciones".

What it does:
- Detects installed Claude Code (`claude --version`) vs latest on npm (`npm view @anthropic-ai/claude-code version`)
- Detects local ClawCode HEAD vs `upstream/main` (when the plugin is a git checkout)
- Prints a compact comparison
- When updates are available, prints the safe procedure: explicit `npm install -g`, explicit `git pull`, explicit `systemctl --user restart` — the same atomic transition #9 wants users to take

What it deliberately doesn't do:
- **Apply updates.** The `claude` user typically can't write to `/usr/local/lib/node_modules/` (root-owned), and even where it can, auto-applying updates from inside the runtime is exactly what #9 disabled. The skill detects and reports; the operator runs the printed commands themselves.

### 2. Heartbeat template gains an "Update check" bullet (`templates/HEARTBEAT.md`)

One line added. Heartbeat fires every 30 min, but the actual network calls are gated:
- **Day-gate** via `memory/.last-update-check` mtime — npm and GitHub don't need polling every 30 min, once per UTC day is plenty
- **Per-version dedupe** via `memory/.notified-versions.json` — each new version is announced exactly once, not every cycle

When a new version is detected, the heartbeat surfaces a short one-line ping with the safe command. Mobile-friendly, no code-block walls.

## Why this pairs with #9

PR #9 turns off the unsafe automatic path. This PR provides the safe manual path and makes sure users don't forget about it. They make sense together; either one without the other is incomplete:

- **#9 alone:** users running ClawCode as a service silently fall behind on Claude Code updates because nothing surfaces "hey, there's a new version" anymore
- **This PR alone:** users still get the auto-update crash loop because the underlying `DISABLE_AUTOUPDATER` knob isn't set

I'd recommend landing them together. If they have to land separately, this one should land *after* #9 so the notification flow's first message isn't "you're 3 versions behind because we just turned off auto-update."

## Permission constraints (worth flagging)

The skill is honest about what it can and can't do in different environments:

| Setup | What works |
|---|---|
| Service running as root | Skill could in principle apply updates itself; this PR still doesn't (separation of concerns) |
| Service running as non-root, claude installed globally as root | Detection works; install commands need to be run by the operator (typical case — we recommend this) |
| Claude installed under user-owned npm prefix | Both detection and install would work; skill still detects-only |

The "operator runs the command" pattern matches how a daemon should be operated — visible, explicit, audit-trail-able.

## What's not changed

- No new code in `lib/` — pure skill + template addition
- Existing agents' `HEARTBEAT.md` files are untouched (the template change applies to newly-created agents). Existing users who want the check can copy the bullet into their own `HEARTBEAT.md`.
- Skill doesn't touch any cron registry or harness state — it's a pure read flow

## Test plan

- [ ] `/agent:update` from CLI: prints comparison block; prints update commands when versions differ; clean output when current
- [ ] `/agent:update` via Telegram: short response, uses `*bold*` not `**bold**`, no walls of bash
- [ ] No network: skill reports "unknown" for upstream values, doesn't error out
- [ ] No git remote `upstream`: ClawCode side reports unknown, Claude Code side still works
- [ ] Plugin not a git checkout: ClawCode side gracefully skipped, Claude Code side still works
- [ ] Heartbeat day-gate: second invocation within 24h skips network calls (verify by checking `memory/.last-update-check` mtime)
- [ ] Per-version dedupe: announcing version X writes to `.notified-versions.json`; subsequent heartbeats see X already-announced and stay quiet; new version Y triggers a new ping

🤖 Generated with [Claude Code](https://claude.com/claude-code)
