### PR TITLE
feat: Task Completion Guard — Stop hook that blocks early termination

### DIFF
--- a/docs/task-guard.md
+++ b/docs/task-guard.md
@@ -1,0 +1,82 @@
+# Task Completion Guard
+
+Persistent task ledger plus a Stop hook that re-prompts the agent while any task still has unmet acceptance criteria. Designed to fix the common frustration that AI assistants stop early on multi-step work.
+
+## How it works
+
+```
+                ┌──────────────────────────┐
+   user asks ──▶│  task_open(goal, [...])  │── writes "open" event
+                └──────────────────────────┘
+                           │
+   agent works  ──▶ task_check(id, c, ev) ── writes "check" event
+                           │
+                  agent tries to stop
+                           │
+                ┌──────────────────────────┐
+                │  Stop hook (TS)          │
+                │  ─ active tasks?         │
+                │     yes → block + reason │   ── re-prompts agent
+                │     no  → allow stop     │
+                └──────────────────────────┘
+                           │
+                  agent finishes
+                           │
+                ┌──────────────────────────┐
+                │  task_close(id, sum)     │── writes "close" event
+                └──────────────────────────┘
+```
+
+## Files
+
+- `lib/task-ledger.ts` — append-only JSONL store + active-task computation.
+- `lib/task-guard-cli.ts` — CLI invoked by the Stop hook, emits the block JSON.
+- `hooks/stop-guard.sh` — thin bash wrapper, reads `CLAUDE_PROJECT_DIR`.
+- `hooks/hooks.json` — wires the guard into the `Stop` event.
+- `server.ts` — exposes `task_open`, `task_check`, `task_close`, `task_list`.
+- `skills/task/SKILL.md` — user-invocable skill describing the workflow.
+
+## Storage
+
+`memory/.tasks/active.jsonl` — append-only JSONL. One event per line:
+
+```json
+{"type":"open","id":"t-a1b2c3d4","goal":"...","criteria":["..."],"createdAt":"2026-04-15T..."}
+{"type":"check","id":"t-a1b2c3d4","criterion":"...","evidence":"...","ts":"2026-04-15T..."}
+{"type":"close","id":"t-a1b2c3d4","summary":"...","closedAt":"2026-04-15T..."}
+```
+
+A task is **active** if its `open` event has no matching `close` event.
+
+## Loop safety
+
+`memory/.tasks/stop-counter.json` tracks consecutive Stop blocks. Once it reaches `taskGuard.maxStopBlocks` (default 5), the guard releases the agent so the session can end. The counter is reset whenever the ledger has zero active tasks. This prevents an agent from being trapped if a task is genuinely impossible.
+
+## Configuration
+
+In `agent-config.json`:
+
+```json
+{
+  "taskGuard": {
+    "enabled": true,
+    "maxStopBlocks": 5
+  }
+}
+```
+
+Set `enabled: false` to disable the Stop block while keeping the ledger tools usable for tracking.
+
+## Failure modes
+
+| Situation | Behaviour |
+|---|---|
+| `agent-config.json` missing or unreadable | Defaults: enabled=true, maxStopBlocks=5. |
+| `tsx`/`node_modules` missing in plugin root | Hook exits 0 — Stop is allowed, no break. |
+| `memory/.tasks/active.jsonl` missing | Guard exits 0 — nothing to enforce. |
+| Malformed JSONL line | Skipped, ledger keeps reading. |
+| Counter cap reached | Guard releases; tasks remain for next session. |
+
+## Why a Stop hook (and not PreToolUse)
+
+The Stop hook is the only lifecycle event triggered by the agent declaring it is done. Re-prompting there is the lightest-touch way to enforce completion — it doesn't interfere with any tool call, doesn't inflate context mid-task, and surrenders cleanly via the counter.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -37,6 +37,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/stop-guard.sh"
+          },
+          {
+            "type": "command",
             "command": "echo '[clawcode] Session ending. If this was a significant conversation, write a brief summary to memory/'$(date +%Y-%m-%d)'.md before closing. Include: what was discussed, decisions made, open items.'"
           }
         ]

--- a/hooks/stop-guard.sh
+++ b/hooks/stop-guard.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# stop-guard.sh — Task Completion Guard (thin wrapper around lib/task-guard-cli.ts)
+#
+# Reads memory/.tasks/active.jsonl. If any task is still open, prints a
+# Stop-hook JSON response that blocks termination and re-prompts the agent
+# with the remaining acceptance criteria. A counter prevents infinite loops.
+set -u
+DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
+ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+
+# Forward stdin (Claude Code's hook payload) to the TS guard.
+cd "$ROOT" 2>/dev/null || exit 0
+exec env CLAWCODE_WORKSPACE="$DIR" \
+  node_modules/.bin/tsx lib/task-guard-cli.ts 2>/dev/null

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -78,6 +78,19 @@ export interface AgentConfig {
     /** Timezone for dreaming cron */
     timezone?: string;
   };
+  /**
+   * Task Completion Guard — Stop-hook policy that re-prompts the agent while
+   * any task in memory/.tasks/active.jsonl still has unmet acceptance criteria.
+   */
+  taskGuard?: {
+    /** Master switch. Default: true (opt-out). */
+    enabled?: boolean;
+    /**
+     * Maximum consecutive Stop blocks before surrendering. Prevents infinite
+     * loops if the agent genuinely can't progress. Default: 5.
+     */
+    maxStopBlocks?: number;
+  };
   memory: {
     /** "builtin" = SQLite+FTS5 (default), "qmd" = QMD external tool */
     backend: "builtin" | "qmd";
@@ -160,6 +173,7 @@ export function loadConfig(pluginRoot: string): AgentConfig {
       memoryContext: parsed.memoryContext ? { ...parsed.memoryContext } : undefined,
       heartbeat: parsed.heartbeat ? { ...parsed.heartbeat } : undefined,
       dreaming: parsed.dreaming ? { ...parsed.dreaming } : undefined,
+      taskGuard: parsed.taskGuard ? { ...parsed.taskGuard } : undefined,
       memory: {
         ...DEFAULT_CONFIG.memory,
         ...parsed.memory,

--- a/lib/task-guard-cli.ts
+++ b/lib/task-guard-cli.ts
@@ -1,0 +1,116 @@
+/**
+ * Task Completion Guard CLI — invoked by hooks/stop-guard.sh on Stop.
+ *
+ * Reads stdin (Claude Code Stop-hook payload), inspects the task ledger,
+ * and emits one of:
+ *   - empty stdout + exit 0  → allow the agent to stop.
+ *   - JSON {"decision":"block","reason":"..."} → re-prompt the agent.
+ *
+ * A counter at memory/.tasks/stop-counter.json caps consecutive blocks at
+ * `taskGuard.maxStopBlocks` (default 5) so the agent can never be trapped.
+ */
+
+import fs from "fs";
+import path from "path";
+import { TaskLedger, type ActiveTask } from "./task-ledger.ts";
+import { loadConfig } from "./config.ts";
+
+interface GuardConfig {
+  enabled: boolean;
+  maxStopBlocks: number;
+}
+
+function readGuardConfig(workspace: string): GuardConfig {
+  try {
+    const cfg = loadConfig(workspace) as { taskGuard?: Partial<GuardConfig> };
+    const tg = cfg.taskGuard || {};
+    return {
+      enabled: tg.enabled !== false,
+      maxStopBlocks: Number.isFinite(tg.maxStopBlocks)
+        ? Math.max(1, Number(tg.maxStopBlocks))
+        : 5,
+    };
+  } catch {
+    return { enabled: true, maxStopBlocks: 5 };
+  }
+}
+
+function readCounter(file: string): number {
+  try {
+    return Number(JSON.parse(fs.readFileSync(file, "utf-8")).count) || 0;
+  } catch {
+    return 0;
+  }
+}
+
+function writeCounter(file: string, count: number): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(
+    file,
+    JSON.stringify({ count, updatedAt: new Date().toISOString() }) + "\n"
+  );
+}
+
+function formatActive(active: ActiveTask[]): string {
+  const lines: string[] = [];
+  for (const t of active) {
+    lines.push(`- Task ${t.id}: ${t.goal}`);
+    for (const c of t.criteria) {
+      const mark = t.evidence[c] ? "[x]" : "[ ]";
+      lines.push(`    ${mark} ${c}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function emitBlock(reason: string): void {
+  process.stdout.write(JSON.stringify({ decision: "block", reason }) + "\n");
+}
+
+function main() {
+  const workspace = process.env.CLAWCODE_WORKSPACE || process.cwd();
+
+  const cfg = readGuardConfig(workspace);
+  if (!cfg.enabled) return; // exit 0, allow stop
+
+  const ledger = new TaskLedger(workspace);
+  let active: ActiveTask[] = [];
+  try {
+    active = ledger.activeTasks();
+  } catch {
+    return;
+  }
+
+  const counterFile = path.join(workspace, "memory", ".tasks", "stop-counter.json");
+
+  if (active.length === 0) {
+    // Reset counter when everything is closed.
+    try { fs.unlinkSync(counterFile); } catch {}
+    return;
+  }
+
+  const prev = readCounter(counterFile);
+  if (prev >= cfg.maxStopBlocks) {
+    // Surrender — let the agent stop. Tasks remain in the ledger for the next
+    // session (or a watchdog) to pick up. Reset so the next stop is fresh.
+    try { fs.unlinkSync(counterFile); } catch {}
+    return;
+  }
+  const next = prev + 1;
+  writeCounter(counterFile, next);
+
+  const reason =
+    `[clawcode/task-guard] You still have open tasks with unmet acceptance criteria. ` +
+    `Continue working until each criterion has evidence, then call task_check ` +
+    `(criterion + evidence) and finally task_close. If a task is genuinely impossible ` +
+    `or no longer relevant, call task_close with force=true and explain why in the summary. ` +
+    `Block ${next}/${cfg.maxStopBlocks}.\n\nOpen tasks:\n${formatActive(active)}`;
+
+  emitBlock(reason);
+}
+
+try {
+  main();
+} catch {
+  // Never break the Stop hook — silent exit means "allow stop".
+}

--- a/lib/task-ledger.ts
+++ b/lib/task-ledger.ts
@@ -1,0 +1,200 @@
+/**
+ * Task ledger — append-only JSONL store of agent tasks with acceptance criteria.
+ *
+ * Backs the Task Completion Guard: the Stop hook reads `activeTasks()` and
+ * blocks the agent from terminating while any task remains open.
+ *
+ * File: memory/.tasks/active.jsonl
+ * Each line is one event:
+ *   { type: "open",  id, goal, criteria, createdAt, source? }
+ *   { type: "check", id, criterion, evidence, ts }
+ *   { type: "close", id, summary, closedAt, force? }
+ *
+ * Active task = an "open" event with no later "close" event for the same id.
+ */
+
+import fs from "fs";
+import path from "path";
+import crypto from "crypto";
+
+export interface TaskOpenEvent {
+  type: "open";
+  id: string;
+  goal: string;
+  criteria: string[];
+  createdAt: string;
+  source?: string;
+}
+
+export interface TaskCheckEvent {
+  type: "check";
+  id: string;
+  criterion: string;
+  evidence: string;
+  ts: string;
+}
+
+export interface TaskCloseEvent {
+  type: "close";
+  id: string;
+  summary: string;
+  closedAt: string;
+  force?: boolean;
+}
+
+export type TaskEvent = TaskOpenEvent | TaskCheckEvent | TaskCloseEvent;
+
+export interface ActiveTask {
+  id: string;
+  goal: string;
+  criteria: string[];
+  createdAt: string;
+  source?: string;
+  satisfied: string[];
+  remaining: string[];
+  evidence: Record<string, string>;
+}
+
+export class TaskLedger {
+  private workspace: string;
+  private dir: string;
+  private file: string;
+
+  constructor(workspace: string) {
+    this.workspace = workspace;
+    this.dir = path.join(workspace, "memory", ".tasks");
+    this.file = path.join(this.dir, "active.jsonl");
+  }
+
+  private ensureDir(): void {
+    fs.mkdirSync(this.dir, { recursive: true });
+  }
+
+  private readEvents(): TaskEvent[] {
+    if (!fs.existsSync(this.file)) return [];
+    const raw = fs.readFileSync(this.file, "utf-8");
+    const out: TaskEvent[] = [];
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        out.push(JSON.parse(trimmed) as TaskEvent);
+      } catch {
+        // Skip malformed lines — ledger remains forward-readable.
+      }
+    }
+    return out;
+  }
+
+  private append(event: TaskEvent): void {
+    this.ensureDir();
+    fs.appendFileSync(this.file, JSON.stringify(event) + "\n");
+  }
+
+  open(goal: string, criteria: string[], source?: string): TaskOpenEvent {
+    const cleanGoal = goal.trim();
+    if (!cleanGoal) throw new Error("goal is required");
+    const cleanCriteria = (criteria || [])
+      .map((c) => String(c || "").trim())
+      .filter((c) => c.length > 0);
+    if (cleanCriteria.length === 0) {
+      throw new Error("at least one acceptance criterion is required");
+    }
+    const id = "t-" + crypto.randomBytes(4).toString("hex");
+    const event: TaskOpenEvent = {
+      type: "open",
+      id,
+      goal: cleanGoal,
+      criteria: cleanCriteria,
+      createdAt: new Date().toISOString(),
+      source,
+    };
+    this.append(event);
+    return event;
+  }
+
+  check(id: string, criterion: string, evidence: string): TaskCheckEvent {
+    const cleanId = String(id || "").trim();
+    const cleanCriterion = String(criterion || "").trim();
+    const cleanEvidence = String(evidence || "").trim();
+    if (!cleanId || !cleanCriterion || !cleanEvidence) {
+      throw new Error("id, criterion, and evidence are all required");
+    }
+    const active = this.activeTasks().find((t) => t.id === cleanId);
+    if (!active) throw new Error(`no active task with id ${cleanId}`);
+    if (!active.criteria.includes(cleanCriterion)) {
+      throw new Error(
+        `criterion "${cleanCriterion}" is not part of task ${cleanId}`
+      );
+    }
+    const event: TaskCheckEvent = {
+      type: "check",
+      id: cleanId,
+      criterion: cleanCriterion,
+      evidence: cleanEvidence,
+      ts: new Date().toISOString(),
+    };
+    this.append(event);
+    return event;
+  }
+
+  close(id: string, summary: string, force = false): TaskCloseEvent {
+    const cleanId = String(id || "").trim();
+    const cleanSummary = String(summary || "").trim();
+    if (!cleanId) throw new Error("id is required");
+    if (!cleanSummary) throw new Error("summary is required to close a task");
+
+    const active = this.activeTasks().find((t) => t.id === cleanId);
+    if (!active) throw new Error(`no active task with id ${cleanId}`);
+    if (!force && active.remaining.length > 0) {
+      throw new Error(
+        `cannot close ${cleanId}: ${active.remaining.length} criteria lack evidence — pass force=true to override or call task_check first`
+      );
+    }
+    const event: TaskCloseEvent = {
+      type: "close",
+      id: cleanId,
+      summary: cleanSummary,
+      closedAt: new Date().toISOString(),
+      force: force || undefined,
+    };
+    this.append(event);
+    return event;
+  }
+
+  activeTasks(): ActiveTask[] {
+    const events = this.readEvents();
+    const opens = new Map<string, TaskOpenEvent>();
+    const closed = new Set<string>();
+    const evidenceById = new Map<string, Record<string, string>>();
+
+    for (const e of events) {
+      if (e.type === "open") opens.set(e.id, e);
+      else if (e.type === "close") closed.add(e.id);
+      else if (e.type === "check") {
+        const ev = evidenceById.get(e.id) || {};
+        ev[e.criterion] = e.evidence;
+        evidenceById.set(e.id, ev);
+      }
+    }
+
+    const active: ActiveTask[] = [];
+    for (const [id, open] of opens) {
+      if (closed.has(id)) continue;
+      const ev = evidenceById.get(id) || {};
+      const satisfied = open.criteria.filter((c) => ev[c]);
+      const remaining = open.criteria.filter((c) => !ev[c]);
+      active.push({
+        id,
+        goal: open.goal,
+        criteria: open.criteria,
+        createdAt: open.createdAt,
+        source: open.source,
+        satisfied,
+        remaining,
+        evidence: ev,
+      });
+    }
+    return active;
+  }
+}

--- a/server.ts
+++ b/server.ts
@@ -49,6 +49,7 @@ import {
 import { extractKeywords } from "./lib/keywords.ts";
 import { MemoryDB } from "./lib/memory-db.ts";
 import { QmdManager } from "./lib/qmd-manager.ts";
+import { TaskLedger } from "./lib/task-ledger.ts";
 import type { SearchResult } from "./lib/types.ts";
 
 // ---------------------------------------------------------------------------
@@ -98,6 +99,9 @@ try {
 
 // Dream engine (always available — uses recall data from .dreams/)
 const dreamEngine = new DreamEngine(WORKSPACE);
+
+// Task ledger (always available — Stop hook reads the same file directly)
+const taskLedger = new TaskLedger(WORKSPACE);
 
 // Initialize QMD if configured (non-blocking, with full error isolation)
 let qmdManager: QmdManager | null = null;
@@ -494,6 +498,10 @@ const MCP_TOOL_DIRECTORY: Array<{ name: string; description: string }> = [
   { name: "chat_inbox_read", description: "Read pending WebChat messages." },
   { name: "webchat_reply", description: "Stream a reply to the open WebChat browser." },
   { name: "watchdog_ping", description: "Cheap liveness probe for external watchdogs — returns version + installed channel plugin names. No LLM, no side effects." },
+  { name: "task_open", description: "Open a tracked task with acceptance criteria. Stop hook will block termination until the task is closed." },
+  { name: "task_check", description: "Record evidence that an acceptance criterion of an open task is satisfied." },
+  { name: "task_close", description: "Close an open task. Refuses unless every criterion has evidence (use force=true to override)." },
+  { name: "task_list", description: "List currently open tasks with their satisfied/remaining criteria." },
 ];
 
 /**
@@ -935,6 +943,61 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
       name: "watchdog_ping",
       description:
         "Cheap liveness probe for external watchdogs. Returns {ok, version, ts, plugins} where plugins is the list of installed channel plugin names (telegram, whatsapp, etc.). No LLM, no side effects, no network I/O. Used by the /watchdog/mcp-ping HTTP endpoint and available directly here for diagnostics.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {},
+      },
+    },
+    {
+      name: "task_open",
+      description:
+        "Open a tracked task with acceptance criteria. The Task Completion Guard Stop hook will re-prompt you each time you try to stop while this task is open and any criterion lacks evidence. Use this when the user assigns a non-trivial task you must finish in this session. Returns the new task id.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          goal: { type: "string", description: "Short statement of what 'done' looks like." },
+          criteria: {
+            type: "array",
+            items: { type: "string" },
+            description: "Concrete acceptance criteria. Each must be verifiable.",
+          },
+          source: { type: "string", description: "Optional — where the task came from (user, schedule, etc.)" },
+        },
+        required: ["goal", "criteria"],
+      },
+    },
+    {
+      name: "task_check",
+      description:
+        "Record evidence that an acceptance criterion of an open task is satisfied. The criterion string must match exactly one of the criteria provided to task_open. Evidence is free-form (a tool-call id, a file path, a test result, etc.).",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          id: { type: "string", description: "Task id returned by task_open." },
+          criterion: { type: "string", description: "Exact criterion text from task_open." },
+          evidence: { type: "string", description: "How you verified it (path:line, test name, command output snippet, etc.)." },
+        },
+        required: ["id", "criterion", "evidence"],
+      },
+    },
+    {
+      name: "task_close",
+      description:
+        "Close an open task. Refuses to close unless every criterion has evidence recorded by task_check. Pass force=true to override (then the summary must explain why).",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          id: { type: "string", description: "Task id returned by task_open." },
+          summary: { type: "string", description: "Brief outcome — what was delivered." },
+          force: { type: "boolean", description: "Override the missing-evidence check. Default false." },
+        },
+        required: ["id", "summary"],
+      },
+    },
+    {
+      name: "task_list",
+      description:
+        "List currently open tasks with their satisfied/remaining criteria. Use this at session start to see what was left unfinished, or before stopping to confirm everything is closed.",
       inputSchema: {
         type: "object" as const,
         properties: {},
@@ -1615,6 +1678,108 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         },
       ],
     };
+  }
+
+  if (name === "task_open") {
+    try {
+      const event = taskLedger.open(
+        String(params.goal || ""),
+        Array.isArray(params.criteria) ? params.criteria.map(String) : [],
+        params.source ? String(params.source) : undefined
+      );
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              `Task ${event.id} opened.\nGoal: ${event.goal}\nCriteria (${event.criteria.length}):\n` +
+              event.criteria.map((c) => `  - ${c}`).join("\n") +
+              `\n\nThe Task Completion Guard will block Stop until each criterion has evidence (task_check) and the task is closed (task_close).`,
+          },
+        ],
+      };
+    } catch (e: any) {
+      return {
+        content: [{ type: "text", text: `Error: ${e?.message || String(e)}` }],
+        isError: true,
+      };
+    }
+  }
+
+  if (name === "task_check") {
+    try {
+      const event = taskLedger.check(
+        String(params.id || ""),
+        String(params.criterion || ""),
+        String(params.evidence || "")
+      );
+      const active = taskLedger
+        .activeTasks()
+        .find((t) => t.id === event.id);
+      const remaining = active ? active.remaining : [];
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              `Recorded evidence for ${event.id}.\nCriterion: ${event.criterion}\nEvidence: ${event.evidence}\nRemaining: ${remaining.length}` +
+              (remaining.length > 0
+                ? "\n  - " + remaining.join("\n  - ")
+                : " — ready to task_close."),
+          },
+        ],
+      };
+    } catch (e: any) {
+      return {
+        content: [{ type: "text", text: `Error: ${e?.message || String(e)}` }],
+        isError: true,
+      };
+    }
+  }
+
+  if (name === "task_close") {
+    try {
+      const event = taskLedger.close(
+        String(params.id || ""),
+        String(params.summary || ""),
+        Boolean(params.force)
+      );
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              `Task ${event.id} closed${event.force ? " (forced)" : ""}.\n` +
+              `Summary: ${event.summary}`,
+          },
+        ],
+      };
+    } catch (e: any) {
+      return {
+        content: [{ type: "text", text: `Error: ${e?.message || String(e)}` }],
+        isError: true,
+      };
+    }
+  }
+
+  if (name === "task_list") {
+    const active = taskLedger.activeTasks();
+    if (active.length === 0) {
+      return {
+        content: [{ type: "text", text: "No open tasks." }],
+      };
+    }
+    const lines: string[] = [`${active.length} open task(s):`, ""];
+    for (const t of active) {
+      lines.push(`- ${t.id}: ${t.goal}`);
+      lines.push(`    opened: ${t.createdAt}${t.source ? ` (source: ${t.source})` : ""}`);
+      for (const c of t.criteria) {
+        const mark = t.evidence[c] ? "[x]" : "[ ]";
+        const ev = t.evidence[c] ? `  → ${t.evidence[c]}` : "";
+        lines.push(`    ${mark} ${c}${ev}`);
+      }
+    }
+    return { content: [{ type: "text", text: lines.join("\n") }] };
   }
 
   return {

--- a/skills/task/SKILL.md
+++ b/skills/task/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: task
+description: Open, inspect, and close tracked tasks guarded by the Stop hook. Use when the user assigns work that must actually be finished — the guard re-prompts you each time you try to stop while criteria are unmet. Triggers "/task open", "/task list", "/task close", "/task check", "track this", "make sure you finish".
+---
+
+# Task Completion Guard
+
+You have an MCP-backed task ledger plus a Stop hook that **refuses to let you stop** while any task in `memory/.tasks/active.jsonl` has unmet acceptance criteria.
+
+## When to open a task
+
+Open a task whenever the user assigns something that:
+- has more than one verifiable step,
+- you might forget about across compactions, or
+- you historically would "stop early" on.
+
+If the user says "track this" / "make sure you finish" / "don't stop until done", **always** open one.
+
+## The four MCP tools
+
+- `task_open(goal, criteria[], source?)` — returns a task id.
+- `task_check(id, criterion, evidence)` — record proof that a criterion is met. `criterion` must match one passed to `task_open` exactly.
+- `task_close(id, summary, force?)` — refuses unless every criterion has evidence. Pass `force: true` only when you're abandoning the task and explain why in `summary`.
+- `task_list()` — shows open tasks with satisfied/remaining criteria.
+
+## Workflow
+
+1. Receive the user request → call `task_open` with crisp criteria.
+2. Do the work. After each meaningful step, call `task_check` with concrete evidence (file path, test output, URL, command).
+3. When all criteria check out, call `task_close` with a one-line summary.
+4. If you genuinely cannot finish (blocked, out of scope, contradicted), call `task_close` with `force: true` and explain — the guard releases.
+
+## Writing good criteria
+
+- ✅ "tests/foo.test.ts passes when run with `npm test`"
+- ✅ "POST /api/users returns 201 with valid body"
+- ✅ "memory/2026-04-15.md contains the deployment summary"
+- ❌ "code looks good" (not verifiable)
+- ❌ "user is happy" (not verifiable by you)
+
+## Stop loop budget
+
+The guard caps consecutive Stop blocks at `taskGuard.maxStopBlocks` (default 5) — after that it surrenders and lets the session end. The unfinished task stays in the ledger; the next session can pick it up via `task_list`.
+
+## Configuration
+
+```json
+{
+  "taskGuard": {
+    "enabled": true,
+    "maxStopBlocks": 5
+  }
+}
+```
+
+Set `enabled: false` in `agent-config.json` to disable the Stop block while keeping the ledger tools available for tracking.


### PR DESCRIPTION
## Summary

- Adds a **Stop hook** backed by an append-only task ledger (`memory/.tasks/active.jsonl`) that re-prompts the agent each time it tries to stop while any tracked task still has unmet acceptance criteria
- Four new MCP tools: `task_open`, `task_check`, `task_close`, `task_list` — the agent opens a task with concrete criteria, records evidence per criterion, and closes when done
- A configurable counter cap (`taskGuard.maxStopBlocks`, default 5) prevents infinite loops — after N blocks the guard surrenders and lets the session end
- New skill (`/task`) with workflow guidance for writing good criteria
- Opt-out via `taskGuard.enabled: false` in `agent-config.json`

## Motivation

The biggest frustration with AI assistants is they stop before the work is actually done. This guard uses Claude Code's Stop hook lifecycle to enforce completion — the agent literally cannot terminate while criteria remain unmet, unless it explicitly force-closes with an explanation.

## Files

| File | Description |
|---|---|
| `lib/task-ledger.ts` | Append-only JSONL event store (open/check/close) |
| `lib/task-guard-cli.ts` | TS CLI invoked by the Stop hook — emits block JSON |
| `hooks/stop-guard.sh` | Thin bash wrapper |
| `hooks/hooks.json` | Wired guard as first Stop hook |
| `lib/config.ts` | Added `taskGuard` config block |
| `server.ts` | 4 MCP tools + TaskLedger initialization |
| `skills/task/SKILL.md` | User-invocable skill |
| `docs/task-guard.md` | Feature documentation |

## Test plan

- [x] Smoke test: open → check → refuse close (missing evidence) → check remaining → close
- [x] Force-close works when criteria can't be met
- [x] Guard emits valid block JSON for runs 1–5, surrenders empty on run 6
- [x] Counter resets when all tasks are closed
- [x] Bash wrapper invokes TS CLI correctly via `exec`
- [x] Invalid criterion rejected with clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)