### PR TITLE
fix(service): Mac PTY wrap parity + remove DISABLE_AUTOUPDATER

### DIFF
--- a/lib/service-generator.ts
+++ b/lib/service-generator.ts
@@ -229,7 +229,13 @@ export function generatePlist(opts: {
 }): string {
   const defaults = opts.skipDefaultArgs ? [] : ["--dangerously-skip-permissions"];
   const args = [...defaults, ...(opts.extraArgs || [])];
-  const argsXml = [opts.claudeBin, ...args]
+  // Wrap the invocation in `/usr/bin/script -q /dev/null <cmd...>` so claude
+  // runs under a pseudo-terminal. Without a PTY, launchd services inherit
+  // stdio that lacks a controlling terminal, which can cause lifecycle hooks
+  // (SessionEnd and others) to fail to spawn subshells and return non-zero,
+  // producing a crash loop under `KeepAlive`. BSD `script(1)` takes positional
+  // args: `script [flags] [typescript] [command args...]`.
+  const argsXml = ["/usr/bin/script", "-q", "/dev/null", opts.claudeBin, ...args]
     .map((a) => `        <string>${xmlEscape(a)}</string>`)
     .join("\n");
 
@@ -299,11 +305,6 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=${opts.workspace}
-# Disable Claude Code's in-process auto-updater while running as a daemon.
-# Background updates have regenerated service files and left the system in
-# inconsistent states; pin the installed version and update explicitly via
-# package manager instead.
-Environment=DISABLE_AUTOUPDATER=1
 ExecStartPre=-/usr/bin/pkill -f "claude.*--dangerously-skip-permissions"
 ExecStart=${execStart}
 Restart=always


### PR DESCRIPTION
Follow-up to #9. Two corrections to the service-install defaults:

**1. macOS PTY wrap parity.**
`generatePlist` now wraps the invocation in `/usr/bin/script -q /dev/null <claudeBin> <args>` (BSD syntax). launchd services run without a controlling TTY by default, same as systemd, so the SessionEnd-hook failure mode #9 fixed on Linux could hit Mac too. This is a preemptive parity fix using the same mechanism Linux got.

Validated locally: `script -q /dev/null claude --version` and `--help` both return exit 0 with clean output, so the wrapper doesn't break the happy path.

**2. Remove `Environment=DISABLE_AUTOUPDATER=1` from the systemd unit.**
JD called this "defense-in-depth" in #9 — the PTY wrap alone suffices to fix the crash-loop. Setting the env var disables a Claude Code feature it ships intentionally, which runs against this plugin's principle of being an OS-level envelope that doesn't modify Claude Code internals. Auto-update returns to working as designed on both platforms.

## Test plan

- [x] `script -q /dev/null /bin/echo hello` → exit 0
- [x] `script -q /dev/null claude --version` → exit 0
- [x] `script -q /dev/null claude --help` → exit 0
- [x] `buildPlan("install", ...)` for darwin emits plist with `/usr/bin/script -q /dev/null` prepended in ProgramArguments
- [x] `buildPlan("install", ...)` for linux emits unit without `DISABLE_AUTOUPDATER=1` line
- [ ] (Deferred) Live reproduction of the crash loop on macOS — would require installing an actual launchd service and waiting for Claude Code to auto-update mid-run, which is invasive. The wrapper is validated to work on the happy path; preemptive parity with the Linux fix is the pragmatic choice.