### PR TITLE
fix(service): re-add DISABLE_AUTOUPDATER=1 to systemd unit

### DIFF
--- a/lib/service-generator.ts
+++ b/lib/service-generator.ts
@@ -305,6 +305,14 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=${opts.workspace}
+# Disable Claude Code's in-process auto-updater while running as a daemon.
+# In a service context the updater can regenerate files it manages mid-run,
+# including the resume-on-restart wrapper script (see generateResumeWrapper).
+# A long-running daemon rewriting its own ExecStart target while live is a
+# file-integrity issue, separate from the PTY-wrap crash-loop fix. Pin the
+# installed version and update explicitly via the /agent:update skill.
+# DISABLE_AUTOUPDATER is a documented env var Claude Code exposes.
+Environment=DISABLE_AUTOUPDATER=1
 ExecStartPre=-/usr/bin/pkill -f "claude.*--dangerously-skip-permissions"
 ExecStart=${execStart}
 Restart=always


### PR DESCRIPTION
## Summary

Follow-up to #16. Proposing to re-add `Environment=DISABLE_AUTOUPDATER=1` in the systemd unit with a clearer rationale. Completely your call on whether to take it. If the removal was intentional after reading the below, happy to close and carry the patch locally on our end.

## Why I think the env var is load-bearing

The PR body on #16 reads the env var as defense-in-depth against the crash loop, with the PTY wrap alone being sufficient. I agree the PTY wrap is the right fix for the SessionEnd-hook failure. The env var is doing something different though.

From #9's commit message: Claude Code's in-process auto-updater regenerates files it manages mid-run, including the resume-on-restart wrapper script generated by #7. A daemon rewriting its own ExecStart target while it is running is a file-integrity problem, not a crash-loop problem, and the PTY wrap does nothing for it. That is the scenario DISABLE_AUTOUPDATER was added for.

## On "don't modify Claude Code internals"

The #16 PR body frames setting the env var as altering Claude Code's behavior. I read that principle the other way: `DISABLE_AUTOUPDATER` is a documented env var Claude Code exposes, verified against the installed cli.js in #9. Setting it is a supported interface, not a monkey-patch of internals. The restored inline comment names the env var and the specific file-regeneration scenario so future readers see the intent.

## Relationship to #12

#12 ships a detect-and-notify skill whose design premise is that in-process auto-update is off in service mode and updates are applied explicitly via the skill. With auto-update running again inside the daemon, the skill's notifications compete with an updater that may silently rewrite service files behind the operator. Whichever way this PR lands, #12 might be worth another look in light of the new default.

## Test plan

- [x] `buildPlan("install", ...)` for linux emits unit with `Environment=DISABLE_AUTOUPDATER=1`
- [x] No change to darwin plist (this PR is systemd-only, matching the original #9 scope). Plist parity can follow if the systemd-side rationale lands.

Not pushing back on #16's intent. Just want the reasoning on the record before the new default settles. Thanks for taking a look.