### PR TITLE
fix(service): re-add DISABLE_AUTOUPDATER=1 (supersedes #17)

### DIFF
--- a/lib/service-generator.ts
+++ b/lib/service-generator.ts
@@ -316,6 +316,14 @@ Type=simple
 WorkingDirectory=${opts.workspace}
 Environment=HOME=${os.homedir()}
 Environment=TERM=xterm-256color
+# Disable Claude Code's in-process auto-updater while running as a daemon.
+# In a service context the updater can regenerate files it manages mid-run,
+# including the resume-on-restart wrapper script (see generateResumeWrapper).
+# A long-running daemon rewriting its own ExecStart target while live is a
+# file-integrity issue, separate from the PTY-wrap crash-loop fix. Pin the
+# installed version and update explicitly via the /agent:update skill.
+# DISABLE_AUTOUPDATER is a documented env var Claude Code exposes.
+Environment=DISABLE_AUTOUPDATER=1
 ExecStartPre=-/usr/bin/pkill -f "claude.*--dangerously-skip-permissions"
 ExecStart=${execStart}
 Restart=always


### PR DESCRIPTION
Conflict-resolved version of #17. JD opened #17 based on pre-#8 `main`, so the insertion point collided with the newly-added `Environment=HOME=`/`Environment=TERM=` lines from #8. Same 8-line block, placed immediately after HOME/TERM so all three env vars sit together.

Accepting JD's rationale in full — #16 incorrectly treated `DISABLE_AUTOUPDATER` as redundant. PTY wrap and `DISABLE_AUTOUPDATER` fix two different problems:

- PTY wrap handles the SessionEnd-hook failure at graceful shutdown.
- `DISABLE_AUTOUPDATER=1` prevents Claude Code's in-process auto-updater from regenerating daemon-relevant files (including the resume wrapper from #7) mid-run.

The env var is a documented Claude Code interface, not a monkey-patch. Full reasoning in #17 stands.

macOS plist unchanged — same scope as JD's #17. Parity fix can follow if and when the systemd-side default settles. Co-authored with @JD2005L.

Closes #17.