### PR TITLE
fix(crons): make jq visible when installed to ~/.local/bin or ~/bin

### DIFF
--- a/hooks/cron-posttool.sh
+++ b/hooks/cron-posttool.sh
@@ -10,6 +10,10 @@
 # See docs/crons.md for the full rationale.
 set -uo pipefail
 
+# See reconcile-crons.sh for the full rationale. Same PATH prefix so jq
+# installed to ~/.local/bin is visible to this hook too.
+export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"
+
 AGENT_ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(dirname "$HOOK_DIR")}"

--- a/hooks/reconcile-crons.sh
+++ b/hooks/reconcile-crons.sh
@@ -8,6 +8,13 @@
 # with a warning on stderr. See docs/crons.md.
 set -uo pipefail
 
+# User-local bindirs first so jq installed to ~/.local/bin (pip --user,
+# Homebrew on Linuxbrew, manual installs) is visible inside systemd user
+# services, launchd LaunchAgents, and any other context that spawns the
+# hook with a minimal inherited PATH. Without this, `command -v jq`
+# returns empty and the hook silently drops into degraded mode.
+export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"
+
 AGENT_ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(dirname "$HOOK_DIR")}"

--- a/skills/crons/writeback.sh
+++ b/skills/crons/writeback.sh
@@ -4,6 +4,11 @@
 # See docs/crons.md for the registry schema and the full lifecycle.
 set -uo pipefail
 
+# Same PATH prefix as the hooks so jq is visible when writeback.sh is
+# invoked from a systemd/launchd context that strips ~/.local/bin from
+# the inherited PATH. Callers in interactive shells are unaffected.
+export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"
+
 AGENT_ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
 MEMORY_DIR="$AGENT_ROOT/memory"
 REGISTRY="$MEMORY_DIR/crons.json"


### PR DESCRIPTION
## Summary

- **Symptom.** On a host with `jq` installed to `~/.local/bin` (pip `--user`, Linuxbrew, manual tarball, etc.), `hooks/reconcile-crons.sh` prints `WARNING: jq not installed. Cron persistence runs in degraded defaults-only mode.` on every SessionStart, and `skills/crons/writeback.sh` exits 3 when invoked outside an interactive shell.
- **Cause.** systemd user services and launchd LaunchAgents inherit a minimal PATH (typically `/usr/bin:/bin` plus whatever `systemctl --user import-environment` picked up) that does not include `~/.local/bin`. The three scripts that use `command -v jq` therefore can't find a user-installed jq even though the binary is sitting right there.
- **Fix.** Prepend `$HOME/.local/bin:$HOME/bin:/usr/local/bin:/opt/homebrew/bin` to PATH at the top of each affected script:
  - `hooks/reconcile-crons.sh`
  - `hooks/cron-posttool.sh`
  - `skills/crons/writeback.sh`
- **Blast radius.** Scoped to each script process (`export PATH=...` in a bash script does not leak outward). No-op on hosts where jq lives in `/usr/bin` or `/usr/local/bin`.

## Secondary effect worth naming

The steady-state fast-path in `hooks/reconcile-crons.sh` (lines 102-110) uses jq to check whether every registry entry has a populated `harnessTaskId`. When jq is invisible, the check always returns non-zero and the hook falls through to the full reconcile envelope on every session start. That's a few hundred milliseconds of blocking tool calls every start, plus the degraded-mode banner on every prompt. The fix closes both at once.

## Test plan

- [x] `bash -n` parses all three modified scripts
- [x] End-to-end PATH resolution verified with `env -i HOME=/home/claude PATH="/usr/bin:/bin" ...` simulating the systemd user service environment. jq at `~/.local/bin/jq` was invisible before the fix; visible after.
- [ ] Real systemd user service verification on the affected host (not available from the sandbox; happy to confirm post-merge)

## Notes

- Related finding still open on the incident writeup: `CronCreate({durable: true})` appears to be ignored on at least one harness build (returns "Session-only (not written to disk, dies when Claude exits)" even with `durable: true`). That's a Claude Code harness bug rather than a ClawCode bug, so not in scope for this PR. Worth filing upstream.
- This is the smaller follow-up to PR #19 (service self-heal). Independent; no dependency on that PR landing first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)