### PR TITLE
feat(service): write boot-time git HEAD to a runtime stamp file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Version stamp at service start.** `generateSystemdUnit` and `generatePlist` now write the workspace's current `git HEAD` to a reboot-clean runtime file (`$XDG_RUNTIME_DIR/clawcode-<slug>.version` on Linux, `$TMPDIR/clawcode-<slug>.version` on macOS) before `claude` boots. The service itself never reads the file; it exists so external watchdogs can detect the "user pulled upstream but only ran `/mcp`" case, where plugins keep serving stale code while systemd still reports the unit as active. On Linux this is a best-effort `ExecStartPre=-/bin/bash -c '...'`; on macOS the whole `ProgramArguments` is wrapped in `/bin/sh -c 'git rev-parse HEAD > $TMPDIR/...; exec "$@"'` with the real argv passed as positionals, so a missing `git` or non-git workspace falls through to the normal exec path instead of crash-looping launchd. New exported `versionStampPathExpr(platform, slug)` helper gives consumers the canonical shell expression for the path. `generatePlist` gains a required `slug` option so the stamp filename can be emitted without re-parsing it out of the label. Five new smoke-test checks cover per-platform expressions, per-slug isolation, ExecStartPre ordering (stamp before exec), the launchd `sh -c` wrapper shape, and `|| true` fallthrough on non-git workspaces. Two watchdog-side consumers land in parallel: `recipes/watchdog/` and the external `claude-telegram-watchdog`. Reported by [@JD2005L](https://github.com/JD2005L) after hitting the silent-stale-code failure mode in production on 2026-04-17.
+
 ## [1.4.1] — 2026-04-17
 
 ### Thanks

--- a/docs/service.md
+++ b/docs/service.md
@@ -225,6 +225,14 @@ If you want an external probe to detect silent failures (plugin subprocess dies 
 
 Full docs: [`docs/watchdog.md`](watchdog.md).
 
+## Version stamp
+
+At service start the unit writes the current `git HEAD` of the workspace to a reboot-clean runtime file (`$XDG_RUNTIME_DIR/clawcode-<slug>.version` on Linux, `$TMPDIR/clawcode-<slug>.version` on macOS). The service never reads this back; it exists purely for external observers.
+
+The motivation: `git pull` followed by `/mcp` doesn't actually reload the plugins from disk. The running session keeps serving stale code, and from the outside everything still looks "active". An external watchdog can compare the stamped SHA against the on-disk HEAD and trigger a restart when they diverge. See [`docs/watchdog.md`](watchdog.md) for the consumer side.
+
+The stamp write is best-effort. It's prefixed with `-` on the systemd `ExecStartPre` and wrapped in `|| true` in the launchd `sh -c`, so a missing `git`, a non-git workspace, or a read-only runtime dir never blocks service start. If the stamp file is absent, downstream watchdogs treat that as "drift detection disabled" rather than as a fault.
+
 ## Implementation
 
 | File | Role |

--- a/lib/service-generator.ts
+++ b/lib/service-generator.ts
@@ -194,6 +194,31 @@ export const HEAL_THRESHOLD = 10;
 export const HEAL_WINDOW_SECONDS = 300;
 export const HEAL_LOG_TAIL_LINES = 200;
 
+/**
+ * Path expression (not literal path) for the version-stamp file the
+ * service writes at boot. The service writes its git HEAD here before
+ * claude starts; external watchdogs (recipes/watchdog,
+ * claude-telegram-watchdog) compare the stamp to the on-disk HEAD and
+ * trigger a restart when they diverge. This catches the case where
+ * the user does `git pull` without restarting the service.
+ *
+ * Returned as a shell expression rather than an absolute path because
+ * $XDG_RUNTIME_DIR (Linux) and $TMPDIR (macOS) resolve at runtime
+ * from the service's environment; both point at reboot-clean
+ * tmpfs/per-user-temp locations, which is exactly the semantics we
+ * want for a "currently-running-version" marker.
+ */
+export function versionStampPathExpr(platform: Platform, slug: string): string {
+  if (platform === "darwin") {
+    // launchd sets TMPDIR per LaunchAgent (typically /var/folders/.../T/).
+    return `"\${TMPDIR%/}/clawcode-${slug}.version"`;
+  }
+  // systemd user services always have XDG_RUNTIME_DIR set; the fallback
+  // handles the pathological case where the unit is started outside a
+  // normal user session.
+  return `"\${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/clawcode-${slug}.version"`;
+}
+
 // ---------------------------------------------------------------------------
 // File content generators
 // ---------------------------------------------------------------------------
@@ -537,6 +562,7 @@ export function generateHealLaunchdPlist(opts: {
 /** Generate a launchd plist. */
 export function generatePlist(opts: {
   label: string;
+  slug: string;
   workspace: string;
   claudeBin: string;
   logPath: string;
@@ -556,7 +582,28 @@ export function generatePlist(opts: {
   // (SessionEnd and others) to fail to spawn subshells and return non-zero,
   // producing a crash loop under `KeepAlive`. BSD `script(1)` takes positional
   // args: `script [flags] [typescript] [command args...]`.
-  const argsXml = ["/usr/bin/script", "-q", "/dev/null", opts.claudeBin, ...args]
+  //
+  // Version stamp wrapper: launchd has no ExecStartPre equivalent, so we
+  // wrap the whole invocation in `/bin/sh -c 'stamp; exec "$@"'` with the
+  // real argv passed as positionals. `exec "$@"` preserves each argv entry
+  // as a separate element (no shell re-parsing) and replaces the sh process,
+  // so the resulting process tree is identical to the pre-stamp version.
+  // See versionStampPathExpr for why the stamp lives in $TMPDIR.
+  const stampExpr = versionStampPathExpr("darwin", opts.slug);
+  const workspaceShell = opts.workspace.replace(/'/g, `'\\''`);
+  const stampScript =
+    `git -C '${workspaceShell}' rev-parse HEAD > ${stampExpr} 2>/dev/null || true; exec "$@"`;
+  const argsXml = [
+    "/bin/sh",
+    "-c",
+    stampScript,
+    "clawcode-service", // $0 (dummy label; exec uses $@ only)
+    "/usr/bin/script",
+    "-q",
+    "/dev/null",
+    opts.claudeBin,
+    ...args,
+  ]
     .map((a) => `        <string>${xmlEscape(a)}</string>`)
     .join("\n");
 
@@ -626,6 +673,17 @@ export function generateSystemdUnit(opts: {
     .join(" ");
   const execStart = `/usr/bin/script -q -c '${innerCmd}' /dev/null`;
 
+  // Version stamp: record the git HEAD we're about to boot with so
+  // external watchdogs can detect post-`git pull` drift. Leading `-`
+  // makes systemd ignore failures (non-git workspace, missing git,
+  // readonly tmpfs) so the stamp is best-effort and never blocks a
+  // legitimate service start. /bin/bash -c for the shell features.
+  const stampExpr = versionStampPathExpr("linux", opts.name);
+  const workspaceShell = opts.workspace.replace(/'/g, `'\\''`);
+  const stampCmd =
+    `/bin/bash -c 'git -C '\\''${workspaceShell}'\\'' rev-parse HEAD > ` +
+    `${stampExpr} 2>/dev/null'`;
+
   return `[Unit]
 Description=ClawCode Agent (${opts.name})
 After=network.target
@@ -644,6 +702,9 @@ Environment=TERM=xterm-256color
 # DISABLE_AUTOUPDATER is a documented env var Claude Code exposes.
 Environment=DISABLE_AUTOUPDATER=1
 ExecStartPre=-/usr/bin/pkill -f "claude.*--dangerously-skip-permissions"
+# Version stamp: see versionStampPathExpr. Watchdogs read this file and
+# trigger a restart when the on-disk HEAD diverges from the stamped SHA.
+ExecStartPre=-${stampCmd}
 ExecStart=${execStart}
 Restart=always
 RestartSec=10
@@ -772,6 +833,7 @@ export function buildPlan(action: ServiceAction, opts: ServiceOptions): ServiceP
       platform === "darwin"
         ? generatePlist({
             label,
+            slug,
             workspace: opts.workspace,
             claudeBin: execBin,
             logPath,

--- a/tests/service-generator-smoke.test.ts
+++ b/tests/service-generator-smoke.test.ts
@@ -20,6 +20,9 @@ import {
   generateHealSystemdService,
   generateHealSystemdTimer,
   generateHealLaunchdPlist,
+  generateSystemdUnit,
+  generatePlist,
+  versionStampPathExpr,
   forceFreshFlagPath,
   healScriptPath,
   healServiceFilePath,
@@ -249,6 +252,126 @@ check("systemd main unit tightened StartLimitBurst=3", () => {
   const plan = buildPlan("install", linuxOpts);
   assert(plan.fileContent.includes("StartLimitBurst=3"), "main unit not tightened to 3");
   assert(!plan.fileContent.includes("StartLimitBurst=5"), "main unit still has old 5");
+});
+
+check("versionStampPathExpr: per-platform + per-slug isolation", () => {
+  const linuxExpr = versionStampPathExpr("linux", "my-agent");
+  assert(linuxExpr.includes("XDG_RUNTIME_DIR"), "linux expr missing XDG_RUNTIME_DIR");
+  assert(linuxExpr.includes("/run/user/$(id -u)"), "linux expr missing /run/user fallback");
+  assert(linuxExpr.includes("clawcode-my-agent.version"), "linux expr missing slug in filename");
+
+  const macExpr = versionStampPathExpr("darwin", "my-agent");
+  assert(macExpr.includes("TMPDIR"), "mac expr missing TMPDIR");
+  assert(macExpr.includes("clawcode-my-agent.version"), "mac expr missing slug in filename");
+  assert(!macExpr.includes("XDG_RUNTIME_DIR"), "mac expr should not reference XDG_RUNTIME_DIR");
+
+  // Two agents must get distinct stamp paths (no cross-talk between
+  // multi-agent installs reading the same file).
+  const a = versionStampPathExpr("linux", "alpha");
+  const b = versionStampPathExpr("linux", "beta");
+  assert(a !== b, "different slugs produced the same stamp path");
+});
+
+check("systemd unit: emits version-stamp ExecStartPre; bash-valid", () => {
+  const unit = generateSystemdUnit({
+    name: "my-agent",
+    workspace: "/home/tester/my-agent",
+    claudeBin: "/usr/local/bin/claude",
+    logPath: "/home/tester/.clawcode/logs/my-agent.log",
+  });
+  // Must have an ExecStartPre line that writes the git HEAD somewhere
+  // named after the slug. Leading `-` on the line makes it best-effort.
+  const stampLine = unit
+    .split("\n")
+    .find((l) => l.startsWith("ExecStartPre=") && l.includes("rev-parse HEAD"));
+  assert(stampLine, "unit missing version-stamp ExecStartPre");
+  assert(stampLine!.startsWith("ExecStartPre=-"), "stamp ExecStartPre not best-effort (missing `-`)");
+  assert(stampLine!.includes("clawcode-my-agent.version"), "stamp path missing per-slug filename");
+  assert(
+    stampLine!.includes("/home/tester/my-agent"),
+    "stamp writer does not target the workspace's git repo"
+  );
+
+  // Bash-parse the payload after /bin/bash -c to catch quoting mistakes.
+  const m = stampLine!.match(/\/bin\/bash -c '(.+)'$/);
+  assert(m, "stamp line not of form `/bin/bash -c '...'`");
+  const payload = m![1].replace(/'\\''/g, "'"); // undo the systemd-level escaping
+  bashSyntaxCheck(payload, "systemd-stamp-payload");
+});
+
+check("systemd unit: stamp runs BEFORE exec (ordering matters)", () => {
+  const unit = generateSystemdUnit({
+    name: "my-agent",
+    workspace: "/home/tester/my-agent",
+    claudeBin: "/usr/local/bin/claude",
+    logPath: "/home/tester/.clawcode/logs/my-agent.log",
+  });
+  const stampIdx = unit.indexOf("rev-parse HEAD");
+  const execIdx = unit.indexOf("ExecStart=");
+  assert(stampIdx > 0 && execIdx > 0, "stamp or exec line missing");
+  assert(stampIdx < execIdx, "stamp must be written before ExecStart");
+});
+
+check("plist: wraps exec via sh -c with stamp write; sh-valid", () => {
+  const plist = generatePlist({
+    label: "com.clawcode.my-agent",
+    slug: "my-agent",
+    workspace: "/Users/tester/my-agent",
+    claudeBin: "/usr/local/bin/claude",
+    logPath: "/Users/tester/.clawcode/logs/my-agent.log",
+  });
+  // ProgramArguments must start with /bin/sh -c ... so the stamp runs
+  // before the real binary. If a future refactor drops that, the stamp
+  // is silently skipped and the drift detector goes blind.
+  const programArgsMatch = plist.match(
+    /<key>ProgramArguments<\/key>\s*<array>([\s\S]+?)<\/array>/
+  );
+  assert(programArgsMatch, "plist missing ProgramArguments");
+  const argEntries = [...programArgsMatch![1].matchAll(/<string>([\s\S]*?)<\/string>/g)].map(
+    (m) => m[1]
+  );
+  assert(argEntries[0] === "/bin/sh", "plist arg[0] not /bin/sh");
+  assert(argEntries[1] === "-c", "plist arg[1] not -c");
+  assert(argEntries[2].includes("rev-parse HEAD"), "plist sh script missing stamp write");
+  assert(argEntries[2].includes("/Users/tester/my-agent"), "plist stamp not targeting workspace");
+  assert(argEntries[2].includes("clawcode-my-agent.version"), "plist stamp missing per-slug filename");
+  // XML-decode first, then assert the script ends with `exec "$@"`.
+  const decoded = argEntries[2]
+    .replace(/&apos;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&gt;/g, ">")
+    .replace(/&lt;/g, "<")
+    .replace(/&amp;/g, "&");
+  assert(decoded.endsWith(`exec "$@"`), "plist sh script must end with exec \"$@\"");
+  // The subsequent argv must include the real binary so `exec "$@"` reaches it.
+  assert(
+    argEntries.some((a) => a === "/usr/local/bin/claude"),
+    "plist argv missing claude binary after sh -c wrapper"
+  );
+  // The embedded script must parse as valid sh.
+  bashSyntaxCheck(decoded, "plist-stamp-script");
+});
+
+check("plist: stamp failure cannot block the service (|| true)", () => {
+  const plist = generatePlist({
+    label: "com.clawcode.my-agent",
+    slug: "my-agent",
+    workspace: "/Users/tester/non-git-workspace",
+    claudeBin: "/usr/local/bin/claude",
+    logPath: "/Users/tester/.clawcode/logs/my-agent.log",
+  });
+  // Without `|| true`, a non-git workspace would make the sh script exit
+  // non-zero before `exec "$@"` runs, and launchd would crash-loop the
+  // service forever. This is the launchd equivalent of the `-` prefix
+  // on the systemd ExecStartPre line.
+  const scriptMatch = plist.match(
+    /<string>(git -C[^<]+rev-parse HEAD[^<]+)<\/string>/
+  );
+  assert(scriptMatch, "plist stamp script not found");
+  assert(
+    scriptMatch![1].includes("|| true"),
+    "plist stamp script must fall through on failure"
+  );
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## The failure mode

A running ClawCode service was found to be serving stale plugin code after I ran `git pull` upstream and then `/mcp` to reload. Ran into this on 2026-04-17 in production.

`/mcp` reloads MCP servers within the running Claude Code process, but it does not re-read plugin code from disk. Only a full service restart (`systemctl --user restart clawcode-<slug>` or `launchctl kickstart`) does that. From the outside there is no way to tell this has happened: systemd and launchd both report the unit as active, all sockets are healthy, the agent responds to messages. It just keeps serving code from whatever HEAD the service was booted with.

## What this PR does

Adds a best-effort write of the workspace's current `git HEAD` to a reboot-clean runtime file at service start, so an external watchdog can diff stamp-vs-disk and restart the service when the two diverge.

- **Linux**: `ExecStartPre=-/bin/bash -c 'git -C <workspace> rev-parse HEAD > \"\${XDG_RUNTIME_DIR:-/run/user/\$(id -u)}/clawcode-<slug>.version\" 2>/dev/null'`. Leading `-` makes it best-effort so a missing git or non-git workspace never blocks start.
- **macOS**: launchd has no `ExecStartPre` equivalent, so the whole `ProgramArguments` array is wrapped in `/bin/sh -c 'stamp; exec \"\$@\"'` with the real argv passed as positionals. `exec \"\$@\"` preserves each argv element as a separate slot with no shell re-parsing, so the resulting process tree is identical to the pre-stamp version. `|| true` on the stamp write gives the same best-effort behavior as the systemd `-` prefix.

## New public helper

`versionStampPathExpr(platform, slug)` returns the canonical shell expression for the stamp path. Watchdog consumers should depend on this rather than hardcoding either path. `generatePlist` now also takes a required `slug` so the stamp filename can be emitted without re-parsing the label.

## Per-slug isolation

Multi-agent installs on one user account now get distinct stamp files (`clawcode-<slug>.version`), so they never read each other's state.

## Safety

The service itself never reads the stamp. If the write fails (missing git, read-only tmpfs, weird filesystem), the stamp file is simply absent and downstream watchdogs treat that as "drift detection disabled" instead of as a fault. No failure mode in which a broken stamp can break the service.

## Tests

23/23 smoke tests green, up from 18. Five new checks:
- `versionStampPathExpr`: per-platform + per-slug isolation
- `systemd unit: emits version-stamp ExecStartPre; bash-valid` (parses the payload with `bash -n`)
- `systemd unit: stamp runs BEFORE exec` (ordering invariant)
- `plist: wraps exec via sh -c with stamp write; sh-valid` (XML-decodes and parses the script)
- `plist: stamp failure cannot block the service` (asserts `|| true` is present)

## Consumers landing in parallel

- `recipes/watchdog/` can grow a drift-detection mode in a follow-up
- [`claude-telegram-watchdog`](https://github.com/JD2005L/claude-telegram-watchdog) already has the consumer side ([commit](https://github.com/JD2005L/claude-telegram-watchdog/commit/0b2477a)): reads `$XDG_RUNTIME_DIR/clawcode-<slug>.version`, compares to the on-disk HEAD, triggers a restart on divergence with a 180s grace period for `update.sh`'s own restart window

## Docs

- `docs/service.md` gets a "Version stamp" section explaining the contract and the best-effort semantics
- `CHANGELOG.md` Unreleased entry

## Not in this PR

- Regenerating existing installs. Current users keep the old unit until they re-run `/agent:service install`. That matches how every prior `generateSystemdUnit` change has landed.