### PR TITLE
docs: community marketplace install path + bump to 1.4.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent",
   "description": "Turn Claude Code into a persistent agent — memory, personality, voice, messaging, and more.",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "author": {
     "name": "Juan Cristobal Andrews"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [1.4.2] — 2026-04-17
+
+### Added
+
+- **Listed on Anthropic's `claude-plugins-community` marketplace.** Install via `/plugin marketplace add anthropics/claude-plugins-community` then `/plugin install clawcode@claude-community`. The plugin entry is registered in the official catalog under the name `clawcode` (the marketplace catalog label) — note this differs from the `agent@clawcode` identifier used when installing from this repo's own marketplace, but both install the same code from the same source. The community marketplace syncs nightly from Anthropic's review pipeline, so brand-new fixes can take up to ~24h to land there; install from `crisandrews/ClawCode` directly if you need the absolute latest commit. The two install paths can coexist on the same machine in different workspaces — they live under separate cache directories (`~/.claude/plugins/cache/claude-community/clawcode/<version>/` vs `~/.claude/plugins/cache/clawcode/agent/<version>/`) and Claude Code tracks them as separate `installed_plugins.json` entries.
+
+### Documentation
+
+- `README.md` — Quick Setup install commands now lead with the community marketplace path; the `crisandrews/ClawCode` path is kept as the bleeding-edge alternative for users who need same-day fixes. Update / uninstall / clear-cache sections refactored to cover both install origins explicitly. Troubleshooting row for the "Failed to reconnect" error now lists both possible cache paths. New badge in the header signaling the community listing.
+
 ## [1.4.1] — 2026-04-17
 
 ### Thanks

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/anthropics/claude-plugins-community"><img src="https://img.shields.io/badge/Listed%20on-Anthropic's%20claude--plugins--community-FF6B35?style=for-the-badge" alt="Listed on Anthropic's claude-plugins-community"></a>
+</p>
+
+<p align="center">
   <a href="#quick-setup">Quick Setup</a> ·
   <a href="#why-it-exists">Why</a> ·
   <a href="#features">Features</a> ·
@@ -80,16 +84,11 @@ claude
 
 **2. Install the plugin.**
 
-Inside Claude Code, add the marketplace:
+Inside Claude Code, add Anthropic's official community marketplace and install:
 
 ```
-/plugin marketplace add crisandrews/ClawCode
-```
-
-Then install the plugin:
-
-```
-/plugin install agent@clawcode
+/plugin marketplace add anthropics/claude-plugins-community
+/plugin install clawcode@claude-community
 ```
 
 When prompted for scope, select **"Install for you, in this repo only (local scope)"** — this keeps the agent isolated to this folder.
@@ -99,6 +98,13 @@ Then reload plugins so the skills become available:
 ```
 /reload-plugins
 ```
+
+> **Bleeding-edge alternative.** The community marketplace syncs nightly from Anthropic's review pipeline, so brand-new fixes can take up to ~24h to land. If you want the absolute latest commit, install from this repo's marketplace instead — same plugin, different identifier:
+>
+> ```
+> /plugin marketplace add crisandrews/ClawCode
+> /plugin install agent@clawcode
+> ```
 
 **3. Create your agent:**
 
@@ -324,7 +330,17 @@ Full details: [`docs/config-reload.md`](docs/config-reload.md)
 
 ## [Updating, uninstalling, and cache](#updating-uninstalling-and-cache)
 
-**Update to the latest version:**
+**Update to the latest version.** Use the command set that matches how you installed.
+
+If you installed from the community marketplace (`clawcode@claude-community`):
+
+```
+/plugin marketplace update anthropics/claude-plugins-community
+/plugin update clawcode@claude-community
+/reload-plugins
+```
+
+If you installed from this repo's marketplace (`agent@clawcode`):
 
 ```
 /plugin marketplace update crisandrews/ClawCode
@@ -332,24 +348,24 @@ Full details: [`docs/config-reload.md`](docs/config-reload.md)
 /reload-plugins
 ```
 
-If `/plugin update` says "already at latest version" but you know there's a new one, use the manual method: type `/plugin`, find `agent@clawcode` in the list, press Enter, and select **Update**.
+If `/plugin update` says "already at latest version" but you know there's a new one, use the manual method: type `/plugin`, find your installed plugin in the list, press Enter, and select **Update**.
 
 Your personality, memory, skills, and config are preserved — only the plugin code updates. No data loss.
 
 **Uninstall:**
 
 ```
-/plugin uninstall agent@clawcode
+/plugin uninstall clawcode@claude-community   # if installed from community marketplace
+/plugin uninstall agent@clawcode              # if installed from this repo's marketplace
 ```
 
 Your agent files (SOUL.md, IDENTITY.md, memory/, skills/) stay in the folder — they're yours. Only the plugin code is removed.
 
-**Clear cache (if reinstall fails or behaves unexpectedly):**
-
-Close Claude, then in terminal:
+**Clear cache (if reinstall fails or behaves unexpectedly).** The cache path depends on which marketplace you installed from. Close Claude, then in terminal:
 
 ```sh
-rm -rf ~/.claude/plugins/cache/clawcode
+rm -rf ~/.claude/plugins/cache/claude-community/clawcode   # community marketplace install
+rm -rf ~/.claude/plugins/cache/clawcode                    # own marketplace install
 ```
 
 Reopen Claude and install again.
@@ -406,7 +422,7 @@ The agent never says "I'm Claude" — it uses its name from IDENTITY.md. Even wh
 
 Run `/agent:doctor` first — it checks everything in one shot. Add `--fix` to auto-repair safe issues.
 
-- **"Failed to reconnect to plugin:agent:clawcode"** — Dependencies didn't install. Check Node.js v18+ (`node --version`). Then try manually: close Claude, run `cd ~/.claude/plugins/cache/clawcode/agent/*/  && npm install`, reopen Claude.
+- **"Failed to reconnect to plugin:agent:clawcode" (or `:clawcode:clawcode` on community installs)** — Dependencies didn't install. Check Node.js v18+ (`node --version`). Then try manually depending on where you installed from: close Claude, run `cd ~/.claude/plugins/cache/clawcode/agent/*/  && npm install` (own marketplace) or `cd ~/.claude/plugins/cache/claude-community/clawcode/*/  && npm install` (community), then reopen Claude.
 - **Agent has no personality** — Run `/mcp` to reload. The SessionStart hook injects identity from SOUL.md + IDENTITY.md.
 - **Memory search returns nothing** — Index builds on first search. For QMD: `agent_config(action='set', key='memory.backend', value='qmd')`.
 - **Agent doesn't remember things** — The active memory reflex uses bilingual synonyms but not everything. Try different keywords.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawcode",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "license": "MIT",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## What this is

ClawCode was accepted into [`anthropics/claude-plugins-community`](https://github.com/anthropics/claude-plugins-community) on 2026-04-17. This PR updates the README so new users land on the community-marketplace install by default, and bumps to v1.4.2 so the listing has a versioned release behind it.

No code changes. No behavior changes. Existing installs (`agent@clawcode` from this repo's marketplace) continue to work unchanged.

## What changed in the README

- **Quick Setup** — leads with `/plugin install clawcode@claude-community`. Existing `agent@clawcode` path moved to a callout box as the "bleeding-edge alternative" for users who want the latest commit (community marketplace syncs nightly, so it can lag by ~24h).
- **Update / Uninstall / Cache** — split into two command sets per origin. Cache paths differ:
  - Community: `~/.claude/plugins/cache/claude-community/clawcode/<version>/`
  - Own marketplace: `~/.claude/plugins/cache/clawcode/agent/<version>/`
- **Troubleshooting** — the "Failed to reconnect" row now lists both possible cache paths.
- **Header badge** — new `Listed on Anthropic's claude-plugins-community` badge below the existing badge row.

## Why the install identifier changed (`agent@clawcode` → `clawcode@claude-community`)

The identifier is `<plugin-entry-name>@<marketplace-name>`. Each marketplace decides the entry name independently:

- This repo's `marketplace.json`: marketplace `clawcode`, plugin entry `agent` → `agent@clawcode`
- Anthropic's `marketplace.json`: marketplace `claude-community`, plugin entry `clawcode` → `clawcode@claude-community`

Anthropic re-labeled the entry to `clawcode` (matching the popular brand/repo name) presumably because `agent` is too ambiguous in a 1636-plugin catalog. The plugin's own `plugin.json` `name` field stays `agent` — renaming it would break every existing user (`installed_plugins.json` keys, `settings.local.json` enabledPlugins, cache paths).

## Out of scope

- No code changes. No version bump beyond what's needed for a release tag.
- No deprecation of the `crisandrews/ClawCode` marketplace path. Both keep working forever — they just route to the same source.

## After merge

1. Tag `v1.4.2`
2. GitHub release with the same callouts
3. Anthropic's nightly sync will eventually pick up the new SHA in their `marketplace.json`