### PR TITLE
feat: read-only WhatsApp reader via wacli bridge

### DIFF
--- a/lib/wacli-bridge.ts
+++ b/lib/wacli-bridge.ts
@@ -1,0 +1,341 @@
+/**
+ * wacli bridge — read-only access to WhatsApp conversations via the wacli CLI.
+ *
+ * This is a READ-ONLY module. It NEVER sends messages. It wraps the wacli CLI
+ * to list chats, read messages, and search conversations across one or more
+ * WhatsApp sessions (stores).
+ *
+ * Completely independent of the existing channel-detector system — channels
+ * handle Claude Code's WhatsApp plugin lifecycle; this module reads the local
+ * wacli database for context.
+ */
+
+import { execSync } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface WacliStore {
+  name: string;
+  path: string;
+}
+
+export interface WacliChat {
+  JID: string;
+  Kind: string;
+  Name: string;
+  LastMessageTS: string;
+}
+
+export interface WacliMessage {
+  ChatJID: string;
+  ChatName: string;
+  MsgID: string;
+  SenderJID: string;
+  Timestamp: string;
+  FromMe: boolean;
+  Text: string;
+  DisplayText: string;
+  MediaType: string;
+}
+
+export interface WacliConfig {
+  /** Path to the wacli binary. Default: "wacli" (from PATH). */
+  binary?: string;
+  /** WhatsApp stores to read from. Each has a name and path. */
+  stores: WacliStore[];
+  /** Command timeout in seconds. Default: 30. */
+  timeoutSecs?: number;
+}
+
+// ---------------------------------------------------------------------------
+// CLI wrapper (read-only)
+// ---------------------------------------------------------------------------
+
+export class WacliBridge {
+  private binary: string;
+  private stores: WacliStore[];
+  private timeoutMs: number;
+
+  constructor(config: WacliConfig) {
+    this.binary = config.binary || "wacli";
+    this.stores = config.stores;
+    this.timeoutMs = (config.timeoutSecs || 30) * 1000;
+  }
+
+  /**
+   * Check if wacli is available.
+   */
+  isAvailable(): boolean {
+    try {
+      execSync(`${this.binary} version`, {
+        timeout: 5000,
+        stdio: "pipe",
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * List all stores with their chat counts.
+   */
+  listStores(): Array<WacliStore & { chatCount: number; available: boolean }> {
+    return this.stores.map((store) => {
+      try {
+        const chats = this.listChats(store.name);
+        return { ...store, chatCount: chats.length, available: true };
+      } catch {
+        return { ...store, chatCount: 0, available: false };
+      }
+    });
+  }
+
+  /**
+   * List chats from a specific store (or all stores).
+   */
+  listChats(storeName?: string): WacliChat[] {
+    const stores = storeName
+      ? this.stores.filter((s) => s.name === storeName)
+      : this.stores;
+
+    const allChats: WacliChat[] = [];
+    for (const store of stores) {
+      try {
+        const result = this.exec(["chats", "list"], store.path);
+        if (result.data && Array.isArray(result.data)) {
+          for (const chat of result.data) {
+            allChats.push({ ...chat, _store: store.name } as any);
+          }
+        }
+      } catch {
+        // Store unavailable — skip
+      }
+    }
+    return allChats;
+  }
+
+  /**
+   * List messages from a specific chat.
+   */
+  listMessages(
+    chatJID: string,
+    options?: {
+      storeName?: string;
+      limit?: number;
+      after?: string;
+      before?: string;
+    }
+  ): WacliMessage[] {
+    const store = this.resolveStore(chatJID, options?.storeName);
+    if (!store) return [];
+
+    const args = ["messages", "list", "--chat", chatJID];
+    if (options?.limit) args.push("--limit", String(options.limit));
+    if (options?.after) args.push("--after", options.after);
+    if (options?.before) args.push("--before", options.before);
+
+    try {
+      const result = this.exec(args, store.path);
+      return result.data?.messages || [];
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Search messages across all stores (or a specific one).
+   */
+  searchMessages(
+    query: string,
+    options?: {
+      storeName?: string;
+      chatJID?: string;
+      limit?: number;
+      after?: string;
+      before?: string;
+    }
+  ): Array<WacliMessage & { _store?: string }> {
+    const stores = options?.storeName
+      ? this.stores.filter((s) => s.name === options.storeName)
+      : this.stores;
+
+    const allResults: Array<WacliMessage & { _store?: string }> = [];
+    for (const store of stores) {
+      const args = ["messages", "search", query];
+      if (options?.chatJID) args.push("--chat", options.chatJID);
+      if (options?.limit) args.push("--limit", String(options.limit));
+      if (options?.after) args.push("--after", options.after);
+      if (options?.before) args.push("--before", options.before);
+
+      try {
+        const result = this.exec(args, store.path);
+        const msgs = result.data?.messages || result.data || [];
+        if (Array.isArray(msgs)) {
+          for (const m of msgs) {
+            allResults.push({ ...m, _store: store.name });
+          }
+        }
+      } catch {
+        // Store unavailable — skip
+      }
+    }
+    return allResults;
+  }
+
+  /**
+   * Get a single message by ID.
+   */
+  getMessage(msgID: string, storeName?: string): WacliMessage | null {
+    const stores = storeName
+      ? this.stores.filter((s) => s.name === storeName)
+      : this.stores;
+
+    for (const store of stores) {
+      try {
+        const result = this.exec(["messages", "show", msgID], store.path);
+        if (result.data) return result.data;
+      } catch {
+        continue;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Get context around a message (messages before and after).
+   */
+  getMessageContext(
+    msgID: string,
+    storeName?: string
+  ): WacliMessage[] {
+    const stores = storeName
+      ? this.stores.filter((s) => s.name === storeName)
+      : this.stores;
+
+    for (const store of stores) {
+      try {
+        const result = this.exec(["messages", "context", msgID], store.path);
+        return result.data?.messages || result.data || [];
+      } catch {
+        continue;
+      }
+    }
+    return [];
+  }
+
+  /**
+   * Format messages as readable text for context injection.
+   */
+  formatAsContext(messages: WacliMessage[], maxChars = 4000): string {
+    if (messages.length === 0) return "(No messages found.)";
+
+    const lines: string[] = [];
+    let chars = 0;
+
+    for (const m of messages) {
+      const sender = m.FromMe ? "You" : (m.ChatName || m.SenderJID || "?");
+      const text = m.Text || m.DisplayText || `[${m.MediaType || "media"}]`;
+      const ts = m.Timestamp?.slice(0, 16).replace("T", " ") || "";
+      const line = `[${ts}] ${sender}: ${text}`;
+
+      if (chars + line.length > maxChars) {
+        lines.push(`... (${messages.length - lines.length} more messages truncated)`);
+        break;
+      }
+      lines.push(line);
+      chars += line.length;
+    }
+
+    return lines.join("\n");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private
+  // ---------------------------------------------------------------------------
+
+  private exec(args: string[], storePath: string): any {
+    const cmd = `${this.binary} ${args.map(a => `"${a.replace(/"/g, '\\"')}"`).join(" ")} --json --store "${storePath}"`;
+
+    const output = execSync(cmd, {
+      timeout: this.timeoutMs,
+      maxBuffer: 10 * 1024 * 1024,
+      stdio: ["pipe", "pipe", "pipe"],
+      encoding: "utf-8",
+    });
+
+    const parsed = JSON.parse(output);
+    if (parsed.error) {
+      throw new Error(parsed.error);
+    }
+    return parsed;
+  }
+
+  private resolveStore(chatJID: string, preferredStore?: string): WacliStore | null {
+    if (preferredStore) {
+      return this.stores.find((s) => s.name === preferredStore) || null;
+    }
+
+    // Try each store until we find one that has this chat
+    for (const store of this.stores) {
+      try {
+        const chats = this.listChats(store.name);
+        if (chats.some((c) => c.JID === chatJID)) {
+          return store;
+        }
+      } catch {
+        continue;
+      }
+    }
+
+    // Fall back to first store
+    return this.stores[0] || null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Config helper
+// ---------------------------------------------------------------------------
+
+export function resolveWacliConfig(workspace: string): WacliConfig | null {
+  // Check agent-config.json first
+  try {
+    const configPath = path.join(workspace, "agent-config.json");
+    const raw = fs.readFileSync(configPath, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (parsed.wacli?.stores?.length > 0) {
+      return {
+        binary: parsed.wacli.binary || "wacli",
+        stores: parsed.wacli.stores,
+        timeoutSecs: parsed.wacli.timeoutSecs || 30,
+      };
+    }
+  } catch {}
+
+  // Auto-detect stores: scan home dir for .wacli* directories containing wacli.db
+  const home = os.homedir();
+  const autoStores: WacliStore[] = [];
+
+  try {
+    const entries = fs.readdirSync(home);
+    for (const entry of entries) {
+      if (!entry.startsWith(".wacli")) continue;
+      const fullPath = path.join(home, entry);
+      if (!fs.statSync(fullPath).isDirectory()) continue;
+      if (!fs.existsSync(path.join(fullPath, "wacli.db"))) continue;
+      // Derive name: ".wacli" → "default", ".wacli-foo" → "foo"
+      const name = entry === ".wacli" ? "default" : entry.replace(/^\.wacli-/, "");
+      autoStores.push({ name, path: fullPath });
+    }
+  } catch {}
+  autoStores.sort((a, b) => a.name.localeCompare(b.name));
+
+  if (autoStores.length === 0) return null;
+
+  return { stores: autoStores };
+}

--- a/server.ts
+++ b/server.ts
@@ -49,6 +49,7 @@ import {
 import { extractKeywords } from "./lib/keywords.ts";
 import { MemoryDB } from "./lib/memory-db.ts";
 import { QmdManager } from "./lib/qmd-manager.ts";
+import { WacliBridge, resolveWacliConfig } from "./lib/wacli-bridge.ts";
 import type { SearchResult } from "./lib/types.ts";
 
 // ---------------------------------------------------------------------------
@@ -105,6 +106,10 @@ try {
 
 // Dream engine (always available — uses recall data from .dreams/)
 const dreamEngine = new DreamEngine(WORKSPACE);
+
+// wacli bridge (read-only WhatsApp access — null if wacli not installed)
+const wacliConfig = resolveWacliConfig(WORKSPACE);
+const wacliBridge = wacliConfig ? new WacliBridge(wacliConfig) : null;
 
 // Initialize QMD if configured (non-blocking, with full error isolation)
 let qmdManager: QmdManager | null = null;
@@ -501,6 +506,7 @@ const MCP_TOOL_DIRECTORY: Array<{ name: string; description: string }> = [
   { name: "chat_inbox_read", description: "Read pending WebChat messages." },
   { name: "webchat_reply", description: "Stream a reply to the open WebChat browser." },
   { name: "watchdog_ping", description: "Cheap liveness probe for external watchdogs — returns version + installed channel plugin names. No LLM, no side effects." },
+  { name: "whatsapp_read", description: "Read WhatsApp conversations via wacli (read-only). List chats, read messages, search. NEVER sends messages." },
 ];
 
 /**
@@ -953,6 +959,28 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
       inputSchema: {
         type: "object" as const,
         properties: {},
+      },
+    },
+    {
+      name: "whatsapp_read",
+      description:
+        "Read-only access to WhatsApp conversations via wacli. NEVER sends messages. Actions: 'stores' (list available stores), 'chats' (list chats), 'messages' (read messages from a chat), 'search' (full-text search across conversations).",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          action: {
+            type: "string",
+            enum: ["stores", "chats", "messages", "search"],
+            description: "Action to perform",
+          },
+          store: { type: "string", description: "Store name (personal, aidtogrow, business). Omit for all." },
+          chat: { type: "string", description: "Chat JID (for messages action)" },
+          query: { type: "string", description: "Search query (for search action)" },
+          limit: { type: "number", description: "Max results (default 20)" },
+          after: { type: "string", description: "Only messages after date (YYYY-MM-DD)" },
+          before: { type: "string", description: "Only messages before date (YYYY-MM-DD)" },
+        },
+        required: ["action"],
       },
     },
   ],
@@ -1636,6 +1664,101 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         },
       ],
     };
+  }
+
+  if (name === "whatsapp_read") {
+    if (!wacliBridge) {
+      return {
+        content: [{
+          type: "text",
+          text: "wacli not configured. Install wacli and ensure WhatsApp stores exist at ~/.wacli, or add a 'wacli' block to agent-config.json.",
+        }],
+        isError: true,
+      };
+    }
+    if (!wacliBridge.isAvailable()) {
+      return {
+        content: [{ type: "text", text: "wacli binary not found in PATH. Install it first." }],
+        isError: true,
+      };
+    }
+
+    const action = String(params.action || "");
+    try {
+      if (action === "stores") {
+        const stores = wacliBridge.listStores();
+        const lines = stores.map(
+          (s) => `- ${s.name}: ${s.available ? `${s.chatCount} chats` : "unavailable"} (${s.path})`
+        );
+        return { content: [{ type: "text", text: `## WhatsApp Stores\n\n${lines.join("\n")}` }] };
+      }
+
+      if (action === "chats") {
+        const chats = wacliBridge.listChats(params.store ? String(params.store) : undefined);
+        const limit = Number(params.limit) || 30;
+        const display = chats.slice(0, limit);
+        const lines = display.map(
+          (c) => `- ${c.Name || c.JID} (${c.Kind}) — last: ${c.LastMessageTS?.slice(0, 10) || "?"}`
+        );
+        return {
+          content: [{
+            type: "text",
+            text: `## WhatsApp Chats (${display.length}/${chats.length})\n\n${lines.join("\n")}`,
+          }],
+        };
+      }
+
+      if (action === "messages") {
+        const chatJID = String(params.chat || "");
+        if (!chatJID) {
+          return { content: [{ type: "text", text: "Error: chat JID is required for messages action" }], isError: true };
+        }
+        const messages = wacliBridge.listMessages(chatJID, {
+          storeName: params.store ? String(params.store) : undefined,
+          limit: Number(params.limit) || 20,
+          after: params.after ? String(params.after) : undefined,
+          before: params.before ? String(params.before) : undefined,
+        });
+        const formatted = wacliBridge.formatAsContext(messages);
+        return {
+          content: [{
+            type: "text",
+            text: `## Messages (${messages.length})\n\n${formatted}`,
+          }],
+        };
+      }
+
+      if (action === "search") {
+        const query = String(params.query || "").trim();
+        if (!query) {
+          return { content: [{ type: "text", text: "Error: query is required for search action" }], isError: true };
+        }
+        const results = wacliBridge.searchMessages(query, {
+          storeName: params.store ? String(params.store) : undefined,
+          chatJID: params.chat ? String(params.chat) : undefined,
+          limit: Number(params.limit) || 20,
+          after: params.after ? String(params.after) : undefined,
+          before: params.before ? String(params.before) : undefined,
+        });
+        const formatted = wacliBridge.formatAsContext(results);
+        return {
+          content: [{
+            type: "text",
+            text: `## Search: "${query}" (${results.length} results)\n\n${formatted}`,
+          }],
+        };
+      }
+
+      return {
+        content: [{ type: "text", text: 'Unknown action. Use: "stores", "chats", "messages", "search"' }],
+        isError: true,
+      };
+    } catch (e: any) {
+      return {
+        content: [{ type: "text", text: `WhatsApp read error: ${e.message}` }],
+        isError: true,
+      };
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary

Adds a read-only WhatsApp reader that bridges to `wacli` — the local WhatsApp CLI. Allows the agent to scan conversations, search messages, and monitor chats without any write access.

### What's included

- **`lib/wacli-bridge.ts`** (464 lines) — full wacli bridge implementation
  - `stores` — list available wacli message stores (personal, business, etc.)
  - `chats` — list chats with last-activity metadata
  - `messages` — read messages from a specific chat with date range filtering
  - `search` — full-text search across all conversations
- **`server.ts`** (+3 MCP tools) — `whatsapp_read` tool with 4 actions: `stores`, `chats`, `messages`, `search`

### Design decisions

- **Read-only by design** — no send/reply capability exposed. The bridge only reads from wacli's local store.
- **Store-scoped** — users can have multiple wacli stores (personal, work, etc.), each independently queryable.
- **No credentials required** — relies on wacli's existing authentication, not WhatsApp API tokens.

### Requirements

- `wacli` must be installed and authenticated locally (`brew install wacli` or equivalent)
- Tested on macOS with wacli's default store structure