### PR TITLE
fix(crons): probe stat -c before stat -f in writeback.sh

### DIFF
--- a/skills/crons/writeback.sh
+++ b/skills/crons/writeback.sh
@@ -55,7 +55,14 @@ _refresh_reconciling_if_fresh() {
   local marker="$MEMORY_DIR/.reconciling"
   [[ -f "$marker" ]] || return 0
   local marker_mtime now_s age
-  marker_mtime=$(stat -f %m "$marker" 2>/dev/null || stat -c %Y "$marker" 2>/dev/null || echo 0)
+  # GNU-first, value-checked probe: on GNU coreutils `stat -f %m` means
+  # "filesystem status" and prints a multi-line block to stdout while exiting
+  # non-zero, so the old BSD-first order let the `||` fallback APPEND the real
+  # epoch — leaving marker_mtime as a blob containing the word "File", which
+  # then trips `set -u` in the arithmetic below. `stat -c %Y` succeeds on GNU
+  # and fails cleanly (no stdout) on BSD/macOS, where `stat -f %m` takes over.
+  marker_mtime=$(stat -c %Y "$marker" 2>/dev/null || stat -f %m "$marker" 2>/dev/null || echo 0)
+  [[ "$marker_mtime" =~ ^[0-9]+$ ]] || marker_mtime=0
   now_s=$(date +%s)
   age=$((now_s - marker_mtime))
   if [[ $age -ge 0 && $age -lt 600 ]]; then


### PR DESCRIPTION
On Linux, `_refresh_reconciling_if_fresh` crashes the script — which breaks `/agent:crons reconcile` and the heartbeat's cron repair.

It reads the marker's mtime with `stat -f %m` first. On GNU coreutils `-f` means "filesystem status", so that prints a multi-line block to stdout *and* exits non-zero — the `|| stat -c %Y` fallback then appends the real epoch, leaving `marker_mtime` as a blob containing the word `File`. The next line's `$((now_s - marker_mtime))` treats `File` as a variable, and `set -u` kills the script.

Repro on any Linux host:

```
touch /tmp/m && stat -f %m /tmp/m   # prints a filesystem block, exits 1
```

Fix: probe `stat -c %Y` first (works on GNU, fails clean on BSD/macOS where `stat -f %m` takes over) — same GNU-first approach already used in `_detect_date_flavor`. Plus a numeric guard so a bad read can't trip `set -u` again.

Hit this on WSL2/Ubuntu; reconcile and audit pass after the change.
