### PR TITLE
fix(crons): probe GNU stat before BSD stat in marker-age checks

### DIFF
--- a/hooks/cron-posttool.sh
+++ b/hooks/cron-posttool.sh
@@ -39,7 +39,7 @@ esac
 
 # --- Recursion guard: suppress capture during SessionStart reconcile. ---
 if [[ -f "$RECONCILING_MARKER" ]]; then
-  marker_mtime=$(stat -f %m "$RECONCILING_MARKER" 2>/dev/null || stat -c %Y "$RECONCILING_MARKER" 2>/dev/null || echo 0)
+  marker_mtime=$(stat -c %Y "$RECONCILING_MARKER" 2>/dev/null || stat -f %m "$RECONCILING_MARKER" 2>/dev/null || echo 0)
   now=$(date +%s)
   age=$((now - marker_mtime))
   if [[ $age -ge 0 && $age -lt $MAX_MARKER_AGE_SEC ]]; then

--- a/hooks/cron-pretool.sh
+++ b/hooks/cron-pretool.sh
@@ -45,7 +45,7 @@ TOOL_NAME=$(printf '%s' "$PAYLOAD" | jq -r '.tool_name // empty' 2>/dev/null)
 # registry's crons through CronCreate. Those calls re-use stored crons
 # and must not be gated.
 if [[ -f "$RECONCILING_MARKER" ]]; then
-  marker_mtime=$(stat -f %m "$RECONCILING_MARKER" 2>/dev/null || stat -c %Y "$RECONCILING_MARKER" 2>/dev/null || echo 0)
+  marker_mtime=$(stat -c %Y "$RECONCILING_MARKER" 2>/dev/null || stat -f %m "$RECONCILING_MARKER" 2>/dev/null || echo 0)
   now=$(date +%s)
   age=$((now - marker_mtime))
   if [[ $age -ge 0 && $age -lt $MAX_RECONCILE_AGE_SEC ]]; then

--- a/skills/crons/writeback.sh
+++ b/skills/crons/writeback.sh
@@ -55,7 +55,7 @@ _refresh_reconciling_if_fresh() {
   local marker="$MEMORY_DIR/.reconciling"
   [[ -f "$marker" ]] || return 0
   local marker_mtime now_s age
-  marker_mtime=$(stat -f %m "$marker" 2>/dev/null || stat -c %Y "$marker" 2>/dev/null || echo 0)
+  marker_mtime=$(stat -c %Y "$marker" 2>/dev/null || stat -f %m "$marker" 2>/dev/null || echo 0)
   now_s=$(date +%s)
   age=$((now_s - marker_mtime))
   if [[ $age -ge 0 && $age -lt 600 ]]; then


### PR DESCRIPTION
Fixes the Linux breakage reported in #36.

## The bug

All three marker-age checks probe `stat -f %m` before falling back to `stat -c %Y`. On GNU coreutils `-f` is `--file-system`, a boolean flag, not a format option — so `stat -f %m <marker>` treats `%m` and the marker as two operands. It exits 1 on the bogus `%m`, so the `||` fallback does fire, but it has *already* written a multi-line filesystem block to stdout. The command substitution captures that block alongside the fallback's epoch, and the arithmetic on the next line dies under `set -u` with `File: unbound variable`.

## Impact on Linux

- `hooks/cron-pretool.sh` — the CronCreate gate dies before it can emit exit 2
- `hooks/cron-posttool.sh` — ad-hoc crons are never captured into the registry
- `skills/crons/writeback.sh` — `set-alive` / `audit` abort for the duration of a SessionStart reconcile

Net effect: cron reconcile is unreliable on Linux, which is a plausible contributor to the orphan-entry symptom in #32.

## The fix

Swap the probe order to GNU-first. This is the convention already used in `bin/cron-from.sh` and `hooks/scope-trust-legacy-warn.sh` — the latter from your own commit `fix(hooks): scope-trust legacy-warn crashed on GNU/Linux (stat -f is --file-system, not format)`. This PR applies that same correction to the three sites it didn't reach.

The order is unambiguous in both directions: on BSD, `stat -c` fails cleanly with no stdout, so the fallback to `-f %m` works exactly as before.

Three lines, no behaviour change on macOS.

## Testing

Verified on Debian (GNU coreutils 9.x, bash 5.2): before the change, a SessionStart reconcile aborted with `File: unbound variable`; after it, reconcile completes and the registry audit reports `alive=2/2 orphaned=0`. Confirmed again in normal use over the past two days.

macOS path unchanged and untested by me — worth a second pair of eyes there, though `stat -c` failing with empty stdout on BSD is well documented.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
